### PR TITLE
Feature/CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1)
+project(BSMPT VERSION 1.0.0 LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake")
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
+set(TOOLSDIR ${CMAKE_SOURCE_DIR}/tools)
+
+find_package(Eigen3 REQUIRED)
+find_package(CMAES REQUIRED)
+find_package(GSL REQUIRED)
+
+
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@ set(TOOLSDIR ${CMAKE_SOURCE_DIR}/tools)
 find_package(Eigen3 REQUIRED)
 find_package(CMAES REQUIRED)
 find_package(GSL REQUIRED)
-
+find_package(OpenMP)
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,18 +5,24 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake")
 
 set(CMAKE_CXX_STANDARD 11)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RELEASE")
+endif(NOT CMAKE_BUILD_TYPE)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
-set(TOOLSDIR ${CMAKE_SOURCE_DIR}/tools)
 
 find_package(Eigen3 REQUIRED)
-
 if(EIGEN3_FOUND AND NOT TARGET Eigen3::Eigen)
   add_library(Eigen3::Eigen INTERFACE IMPORTED)
   set_target_properties(Eigen3::Eigen PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
 endif()
 
+if(NOT CMAES_ROOT)
+  set(CMAES_ROOT "${CMAKE_SOURCE_DIR}/tools")
+endif()
 find_package(CMAES REQUIRED)
+
 find_package(GSL REQUIRED)
 find_package(OpenMP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
 set(TOOLSDIR ${CMAKE_SOURCE_DIR}/tools)
 
 find_package(Eigen3 REQUIRED)
+
+if(EIGEN3_FOUND AND NOT TARGET Eigen3::Eigen)
+  add_library(Eigen3::Eigen INTERFACE IMPORTED)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
+endif()
+
 find_package(CMAES REQUIRED)
 find_package(GSL REQUIRED)
 find_package(OpenMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(BSMPT VERSION 1.0.0 LANGUAGES CXX)
+project(BSMPT VERSION 1.0.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_subdirectory(minimizer)
+add_subdirectory(models)
+
+add_executable(BSMPT prog/BSMPT.cpp)
+target_link_libraries(BSMPT Minimizer Models)
+
+add_executable(VEVEVO prog/VEVEVO.cpp)
+target_link_libraries(VEVEVO Minimizer Models)
+
+add_executable(NLOVEV prog/NLOVEV.cpp)
+target_link_libraries(NLOVEV Minimizer Models)
+
+add_executable(CalcCT prog/CalcCT.cpp)
+target_link_libraries(CalcCT Models)
+
+add_executable(TripleHiggsCouplingsNLO prog/TripleHiggsNLO.cpp)
+target_link_libraries(TripleHiggsCouplingsNLO Models)

--- a/src/minimizer/CMakeLists.txt
+++ b/src/minimizer/CMakeLists.txt
@@ -5,3 +5,4 @@ add_library(Minimizer
 )
 target_include_directories( Minimizer PUBLIC ${EIGEN3_INCLUDE_DIR})
 target_link_libraries(Minimizer PRIVATE CMAES)
+target_compile_options(Minimizer PUBLIC ${OpenMP_CXX_FLAGS})

--- a/src/minimizer/CMakeLists.txt
+++ b/src/minimizer/CMakeLists.txt
@@ -3,6 +3,5 @@ add_library(Minimizer
   MinimizeGSL.cpp
   Minimizer.cpp
 )
-target_include_directories( Minimizer PUBLIC ${EIGEN3_INCLUDE_DIR})
-target_link_libraries(Minimizer PRIVATE CMAES)
+target_link_libraries(Minimizer PUBLIC CMAES Eigen3::Eigen GSL::gsl)
 target_compile_options(Minimizer PUBLIC ${OpenMP_CXX_FLAGS})

--- a/src/minimizer/CMakeLists.txt
+++ b/src/minimizer/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(Minimizer
+  Minfunc_gen.cpp
+  MinimizeGSL.cpp
+  Minimizer.cpp
+)
+target_include_directories( Minimizer PUBLIC ${EIGEN3_INCLUDE_DIR})
+target_link_libraries(Minimizer PRIVATE CMAES)

--- a/src/minimizer/Minimizer.h
+++ b/src/minimizer/Minimizer.h
@@ -21,11 +21,11 @@
 #define MINIMIZER_H_
 
 #include "../models/IncludeAllModels.h"
-#include "cmaes.h"
-#include <cmaparameters.h>
-#include "esoptimizer.h"
-#include "cmastrategy.h"
-#include "llogging.h"
+#include "libcmaes/cmaes.h"
+#include "libcmaes/cmaparameters.h"
+#include "libcmaes/esoptimizer.h"
+#include "libcmaes/cmastrategy.h"
+#include "libcmaes/llogging.h"
 #include <random>
 #include <memory>
 
@@ -60,4 +60,3 @@ struct PointerContainer{
 };
 
 #endif /* MINIMIZER_H_ */
-

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(Models
+  ClassPotentialC2HDM.cpp
+  ClassPotentialOrigin.cpp
+  ClassPotentialR2HDM.cpp
+  ClassPotentialRN2HDM.cpp
+  ClassTemplate.cpp
+  IncludeAllModels.cpp
+)
+target_include_directories( Models PUBLIC ${EIGEN3_INCLUDE_DIR})
+target_link_libraries( Models PUBLIC CMAES GSL::gsl)

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -6,5 +6,4 @@ add_library(Models
   ClassTemplate.cpp
   IncludeAllModels.cpp
 )
-target_include_directories( Models PUBLIC ${EIGEN3_INCLUDE_DIR})
-target_link_libraries( Models PUBLIC CMAES GSL::gsl)
+target_link_libraries( Models PUBLIC CMAES GSL::gsl Eigen3::Eigen)

--- a/src/models/ClassPotentialOrigin.h
+++ b/src/models/ClassPotentialOrigin.h
@@ -56,7 +56,7 @@
 *4) Afterwards type  `./autogen.sh --lib=PathToLib --CXX=YourC++Compiler`  in order to create a makefile in the
  *  main path, with the libraries installed in 'PathToLib'.
 *
-*5) Finally go back to the main directory and type 'make'. 
+*5) Finally go back to the main directory and type 'make'.
  *
  *   *  [1] http://www.gnu.org/software/gsl/
  *
@@ -157,16 +157,16 @@
  */
 
 
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
-#include <Eigen/IterativeLinearSolvers>
+#include "Eigen/Dense"
+#include "Eigen/Eigenvalues"
+#include "Eigen/IterativeLinearSolvers"
 
 #include <complex>
-#include<array>
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <iomanip>
-#include<sstream>
+#include <sstream>
 #include <limits>
 #include <algorithm>
 #include <cmath>

--- a/tools/cmake/FindCMAES.cmake
+++ b/tools/cmake/FindCMAES.cmake
@@ -1,18 +1,22 @@
+if(DEFINED ENV{CMAES_ROOT})
+  set(CMAES_ROOT $ENV{CMAES_ROOT})
+endif(DEFINED ENV{CMAES_ROOT})
+
 find_library( CMAES_LIBRARY
   NAMES cmaes
-  HINTS ${TOOLSDIR}/lib ${TOOLSDIR}/lib64
+  HINTS ${CMAES_ROOT}/lib ${CMAES_ROOT}/lib64
   DOC "path to cmaes library"
 )
 
 find_path( CMAES_INCLUDE_DIR
   NAMES libcmaes/cmaes.h
-  HINTS ${TOOLSDIR}/include/
+  HINTS ${CMAES_ROOT}/include/
   DOC "cmaes include directory"
 )
 
 if(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
   MESSAGE(STATUS "libCMAES not found, downloading...")
-  file(MAKE_DIRECTORY ${TOOLSDIR})
+  file(MAKE_DIRECTORY ${CMAES_ROOT})
   file(
 			DOWNLOAD
 				https://github.com/beniz/libcmaes/archive/0.9.5.tar.gz
@@ -26,12 +30,13 @@ if(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
 			COMMAND ./autogen.sh
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
 		)
+    file(WRITE ${CMAKE_BINARY_DIR}/libcmaes-0.9.5/cmaes_export.h "#define CMAES_EXPORT")
     execute_process(
       COMMAND ./configure
         CC=${CMAKE_C_COMPILER}
         CXX=${CMAKE_CXX_COMPILER}
         --with-eigen3-include=${EIGEN3_INCLUDE_DIR}
-        --prefix=${TOOLSDIR}
+        --prefix=${CMAES_ROOT}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
     )
     execute_process(
@@ -41,6 +46,17 @@ if(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
     execute_process(
       COMMAND make install
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
+    )
+    find_library( CMAES_LIBRARY
+      NAMES cmaes
+      HINTS ${CMAES_ROOT}/lib ${CMAES_ROOT}/lib64
+      DOC "path to cmaes library"
+    )
+
+    find_path( CMAES_INCLUDE_DIR
+      NAMES libcmaes/cmaes.h
+      HINTS ${CMAES_ROOT}/include/
+      DOC "cmaes include directory"
     )
 endif(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
 

--- a/tools/cmake/FindCMAES.cmake
+++ b/tools/cmake/FindCMAES.cmake
@@ -1,0 +1,67 @@
+find_library( CMAES_LIBRARY
+  NAMES cmaes
+  HINTS ${TOOLSDIR}/lib ${TOOLSDIR}/lib64
+  DOC "path to cmaes library"
+)
+
+find_path( CMAES_INCLUDE_DIR
+  NAMES libcmaes/cmaes.h
+  HINTS ${TOOLSDIR}/include/
+  DOC "cmaes include directory"
+)
+
+if(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
+  MESSAGE(STATUS "libCMAES not found, downloading...")
+  file(MAKE_DIRECTORY ${TOOLSDIR})
+  file(
+			DOWNLOAD
+				https://github.com/beniz/libcmaes/archive/0.9.5.tar.gz
+				${CMAKE_BINARY_DIR}/libcmaes.tar.gz
+		)
+		execute_process(
+			COMMAND
+				${CMAKE_COMMAND} -E tar xzf ${CMAKE_BINARY_DIR}/libcmaes.tar.gz
+		)
+    execute_process(
+			COMMAND ./autogen.sh
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
+		)
+    execute_process(
+      COMMAND ./configure
+        CC=${CMAKE_C_COMPILER}
+        CXX=${CMAKE_CXX_COMPILER}
+        --with-eigen3-include=${EIGEN3_INCLUDE_DIR}
+        --prefix=${TOOLSDIR}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
+    )
+    execute_process(
+      COMMAND make
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
+    )
+    execute_process(
+      COMMAND make install
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/libcmaes-0.9.5
+    )
+endif(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args( CMAES
+  FOUND_VAR
+    CMAES_FOUND
+  REQUIRED_VARS
+    CMAES_LIBRARY
+    CMAES_INCLUDE_DIR
+)
+
+if(CMAES_FOUND AND NOT TARGET CMAES)
+  add_library(CMAES UNKNOWN IMPORTED)
+  set_property(
+    TARGET CMAES
+    PROPERTY IMPORTED_LOCATION ${CMAES_LIBRARY}
+  )
+  set_property(
+    TARGET CMAES
+    PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+      ${CMAES_INCLUDE_DIR}
+  )
+endif(CMAES_FOUND AND NOT TARGET CMAES)

--- a/tools/cmake/FindCMAES.cmake
+++ b/tools/cmake/FindCMAES.cmake
@@ -21,6 +21,8 @@ if(NOT CMAES_LIBRARY OR NOT CMAES_INCLUDE_DIR)
 			DOWNLOAD
 				https://github.com/beniz/libcmaes/archive/0.9.5.tar.gz
 				${CMAKE_BINARY_DIR}/libcmaes.tar.gz
+      EXPECTED_MD5
+        ab89fde799f1e938ffd74fa66ab77153
 		)
 		execute_process(
 			COMMAND

--- a/tools/cmake/FindEigen3.cmake
+++ b/tools/cmake/FindEigen3.cmake
@@ -1,0 +1,97 @@
+# - Try to find Eigen3 lib
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Eigen3 3.1.2)
+# to require version 3.1.2 or newer of Eigen3.
+#
+# Once done this will define
+#
+#  EIGEN3_FOUND - system has eigen lib with correct version
+#  EIGEN3_INCLUDE_DIR - the eigen include directory
+#  EIGEN3_VERSION - eigen version
+#
+# This module reads hints about search locations from 
+# the following enviroment variables:
+#
+# EIGEN3_ROOT
+# EIGEN3_ROOT_DIR
+
+# Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+# Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+# Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+# Redistribution and use is allowed according to the terms of the 2-clause BSD license.
+
+if(NOT Eigen3_FIND_VERSION)
+  if(NOT Eigen3_FIND_VERSION_MAJOR)
+    set(Eigen3_FIND_VERSION_MAJOR 2)
+  endif(NOT Eigen3_FIND_VERSION_MAJOR)
+  if(NOT Eigen3_FIND_VERSION_MINOR)
+    set(Eigen3_FIND_VERSION_MINOR 91)
+  endif(NOT Eigen3_FIND_VERSION_MINOR)
+  if(NOT Eigen3_FIND_VERSION_PATCH)
+    set(Eigen3_FIND_VERSION_PATCH 0)
+  endif(NOT Eigen3_FIND_VERSION_PATCH)
+
+  set(Eigen3_FIND_VERSION "${Eigen3_FIND_VERSION_MAJOR}.${Eigen3_FIND_VERSION_MINOR}.${Eigen3_FIND_VERSION_PATCH}")
+endif(NOT Eigen3_FIND_VERSION)
+
+macro(_eigen3_check_version)
+  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+
+  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+
+  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK FALSE)
+  else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK TRUE)
+  endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+
+  if(NOT EIGEN3_VERSION_OK)
+
+    message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
+                   "but at least version ${Eigen3_FIND_VERSION} is required")
+  endif(NOT EIGEN3_VERSION_OK)
+endmacro(_eigen3_check_version)
+
+if (EIGEN3_INCLUDE_DIR)
+
+  # in cache already
+  _eigen3_check_version()
+  set(EIGEN3_FOUND ${EIGEN3_VERSION_OK})
+
+else (EIGEN3_INCLUDE_DIR)
+  
+  # search first if an Eigen3Config.cmake is available in the system,
+  # if successful this would set EIGEN3_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(Eigen3 ${Eigen3_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT EIGEN3_INCLUDE_DIR)
+    find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+        HINTS
+        ENV EIGEN3_ROOT 
+        ENV EIGEN3_ROOT_DIR
+        PATHS
+        ${CMAKE_INSTALL_PREFIX}/include
+        ${KDE4_INCLUDE_DIR}
+        PATH_SUFFIXES eigen3 eigen
+      )
+  endif(NOT EIGEN3_INCLUDE_DIR)
+
+  if(EIGEN3_INCLUDE_DIR)
+    _eigen3_check_version()
+  endif(EIGEN3_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
+
+  mark_as_advanced(EIGEN3_INCLUDE_DIR)
+
+endif(EIGEN3_INCLUDE_DIR)
+


### PR DESCRIPTION
Use cmake as a replacement for the InstallLibraries and autogen scripts. Usage becomes:
`mkdir build && cmake .. && make`

This will check for gsl and eigen3 installations and use those. (So no more manual eigen3 install, which should be unnecessary as it can be installed via package manager on most linux distros and on mac.)
It also checks if libCMAES is installed in the path or already installed in the `tools` subdirectory. If it is not found libCMAES is downloaded, compiled and installed to this directory. CMake also checks if the compiler supports openmp and adds the corresponding flags.

I also fixed some related bugs with include directives. Some eigen and cmaes includes were using the `#include <...>` syntax instead of `#include "..."` which means that the system installation was used instead of the local one. I also updated the cmaes includes to e.g. "libcmaes/cmaes.h" instead of simply `cmaes.h`. T.b.h. I am not entirely sure how that worked before.

None of these changes break the old compilation setup, but provide a complete replacement.