### PR TITLE
added eigen submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/eigen-git-mirror"]
+	path = tools/eigen-git-mirror
+	url = git@github.com:eigenteam/eigen-git-mirror.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
 
 find_package(Eigen3 REQUIRED)
-if(EIGEN3_FOUND AND NOT TARGET Eigen3::Eigen)
-  add_library(Eigen3::Eigen INTERFACE IMPORTED)
-  set_target_properties(Eigen3::Eigen PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
-endif()
-
-if(NOT CMAES_ROOT)
-  set(CMAES_ROOT "${CMAKE_SOURCE_DIR}/tools")
-endif()
 find_package(CMAES REQUIRED)
-
 find_package(GSL REQUIRED)
 find_package(OpenMP)
 

--- a/tools/cmake/FindCMAES.cmake
+++ b/tools/cmake/FindCMAES.cmake
@@ -4,13 +4,13 @@ endif(DEFINED ENV{CMAES_ROOT})
 
 find_library( CMAES_LIBRARY
   NAMES cmaes
-  HINTS ${CMAES_ROOT}/lib ${CMAES_ROOT}/lib64
+  HINTS ${CMAES_ROOT}/lib ${CMAES_ROOT}/lib64 ${CMAKE_SOURCE_DIR}/tools/lib ${CMAKE_SOURCE_DIR}/tools/lib64
   DOC "path to cmaes library"
 )
 
 find_path( CMAES_INCLUDE_DIR
   NAMES libcmaes/cmaes.h
-  HINTS ${CMAES_ROOT}/include/
+  HINTS ${CMAES_ROOT}/include/ ${CMAKE_SOURCE_DIR}/tools/include
   DOC "cmaes include directory"
 )
 

--- a/tools/cmake/FindEigen3.cmake
+++ b/tools/cmake/FindEigen3.cmake
@@ -67,11 +67,17 @@ if (EIGEN3_INCLUDE_DIR)
 
 else (EIGEN3_INCLUDE_DIR)
   
-  # search first if an Eigen3Config.cmake is available in the system,
+  # check if the submodule is present and use it
+  find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+    PATHS ${CMAKE_SOURCE_DIR}/tools/eigen-git-mirror
+  )
+
+  # search if an Eigen3Config.cmake is available in the system,
   # if successful this would set EIGEN3_INCLUDE_DIR and the rest of
   # the script will work as usual
   find_package(Eigen3 ${Eigen3_FIND_VERSION} NO_MODULE QUIET)
 
+  # finally check for a local version is specified by the environement variables
   if(NOT EIGEN3_INCLUDE_DIR)
     find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
         HINTS
@@ -88,10 +94,17 @@ else (EIGEN3_INCLUDE_DIR)
     _eigen3_check_version()
   endif(EIGEN3_INCLUDE_DIR)
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
-
-  mark_as_advanced(EIGEN3_INCLUDE_DIR)
-
 endif(EIGEN3_INCLUDE_DIR)
 
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Eigen3 
+  "Could not find the required Eigen3 library. You can use \n`git submodule update --init ${CMAKE_SOURCE_DIR}/tools/eigen-git-mirror`\n to download a local copy."
+   EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
+
+if(EIGEN3_FOUND AND NOT TARGET Eigen3::Eigen)
+  add_library(Eigen3::Eigen INTERFACE IMPORTED)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
+endif()
+   
+mark_as_advanced(EIGEN3_INCLUDE_DIR)


### PR DESCRIPTION
with cmake support

If eigen3 is not found cmake gives a message telling to initialise the git submodule. If the submodule in tools/eigen-git-mirror is present this version of eigen3 will be preferred.