### PR TITLE
89 throw statusflag more distinctively

### DIFF
--- a/src/minimizer/Minimizer.cpp
+++ b/src/minimizer/Minimizer.cpp
@@ -327,6 +327,15 @@ PTFinder_gen_all(const std::shared_ptr<Class_Potential_Origin> &modelPointer,
   solStartPot = modelPointer->MinimizeOrderVEV(solStart);
   vStart      = modelPointer->EWSBVEV(solStartPot);
 
+  if (vStart <= C_threshold or vStart >= 255.0)
+  {
+    result.Tc         = TempEnd;
+    result.vc         = 0;
+    result.StatusFlag = MinimizerStatus::NLOVEVZEROORINF;
+    result.EWMinimum  = std::vector<double>(dim, 0);
+    return result;
+  }
+
   bool SurviveNLO = modelPointer->CheckNLOVEV(solStart);
 
   if (not SurviveNLO and TempStart == 0)
@@ -335,15 +344,6 @@ PTFinder_gen_all(const std::shared_ptr<Class_Potential_Origin> &modelPointer,
     result.vc         = vStart;
     result.StatusFlag = MinimizerStatus::NOTNLOSTABLE;
     result.EWMinimum  = solStart;
-    return result;
-  }
-
-  if (vStart <= C_threshold or vStart >= 255.0)
-  {
-    result.Tc         = TempEnd;
-    result.vc         = 0;
-    result.StatusFlag = MinimizerStatus::NLOVEVZEROORINF;
-    result.EWMinimum  = std::vector<double>(dim, 0);
     return result;
   }
 

--- a/src/prog/BSMPT.cpp
+++ b/src/prog/BSMPT.cpp
@@ -151,15 +151,38 @@ try
                               std::to_string(VEVsym.at(i)) + " GeV");
           }
         }
-        else if (EWPT.Tc == 300)
+        else if (EWPT.StatusFlag ==
+                 Minimizer::MinimizerStatus::NOTVANISHINGATFINALTEMP)
         {
-          Logger::Write(LoggingLevel::Default,
-                        dimensionnames.at(1) + " != 0 GeV at T = 300 GeV.");
+          Logger::Write(
+              LoggingLevel::Default,
+              dimensionnames.at(1) +
+                  " != 0 GeV at T = 300 GeV. No SFOEWPT is possible.");
         }
-        else if (EWPT.Tc == 0)
+        else if (EWPT.StatusFlag == Minimizer::MinimizerStatus::NLOVEVZEROORINF)
         {
           Logger::Write(LoggingLevel::Default,
-                        "This point is not vacuum stable.");
+                        dimensionnames.at(1) + " = 0 / > 255 GeV at T = 0 GeV. "
+                                               "The point is not NLO stable.");
+        }
+        else if (EWPT.StatusFlag == Minimizer::MinimizerStatus::NOTNLOSTABLE)
+        {
+          Logger::Write(
+              LoggingLevel::Default,
+              dimensionnames.at(1) +
+                  " != vEW GeV at T = 0 GeV. The point is not NLO stable.");
+        }
+        else if (EWPT.StatusFlag ==
+                 Minimizer::MinimizerStatus::NUMERICALLYUNSTABLE)
+        {
+          Logger::Write(LoggingLevel::Default,
+                        "The point is numerically unstable.");
+        }
+        else if (EWPT.StatusFlag == Minimizer::MinimizerStatus::BELOWTHRESHOLD)
+        {
+          Logger::Write(LoggingLevel::Default,
+                        dimensionnames.at(1) + " < " + std::to_string(C_PT) +
+                            " found.");
         }
       }
       if (PrintErrorLines)


### PR DESCRIPTION
Order in `PTFinder_gen_all` is changed, more detailed status output in `BSMPT.cpp`. Closes #89.