### PR TITLE
Feature/sm as input and add unit test for Debye calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,8 @@ if(BSMPT_IS_TOPLEVEL)
       "${CMAKE_CURRENT_SOURCE_DIR}/include/"
       "${CMAKE_CURRENT_SOURCE_DIR}/src/"
       "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
-      "${CMAKE_CURRENT_SOURCE_DIR}/Changelog.md")
+      "${CMAKE_CURRENT_SOURCE_DIR}/Changelog.md"
+      "${CMAKE_CURRENT_SOURCE_DIR}/tests/")
 
   else()
     message(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(
   BSMPT
-  VERSION 2.5.1
+  VERSION 2.6.0
   LANGUAGES C CXX
   DESCRIPTION
     "BSMPT - Beyond the Standard Model Phase Transitions : A C++ package for the computation of the EWPT in BSM models"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 2.5.1
+Program: BSMPT version 2.6.0
 
 Released by: Philipp Basler and Lisa Biermann and Margarete Mühlleitner and Jonas Müller
 
@@ -18,7 +18,6 @@ Released by: Philipp Basler and Lisa Biermann and Margarete Mühlleitner and Jon
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/phbasler/bsmpt/graphs/commit-activity)
 [![GitHub license](https://img.shields.io/github/license/phbasler/bsmpt.svg)](https://github.com/phbasler/BSMPT/blob/master/LICENSE.md)
 [![Latest release](https://badgen.net/github/release/phbasler/bsmpt)](https://github.com/phbasler/bsmpt/releases)
-[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/phbasler/BSMPT.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/phbasler/BSMPT/context:cpp)
 
 
 

--- a/include/BSMPT/baryo_calculation/CalculateEtaInterface.h
+++ b/include/BSMPT/baryo_calculation/CalculateEtaInterface.h
@@ -16,6 +16,7 @@
 #include <BSMPT/baryo_calculation/transport_equations.h>
 #include <BSMPT/minimizer/Minimizer.h>
 #include <BSMPT/models/IncludeAllModels.h>
+#include <BSMPT/models/SMparam.h>
 #include <string>
 #include <vector>
 
@@ -105,13 +106,21 @@ protected:
    */
   GSL_integration_mubl GSL_integration_mubl_container;
 
+  /**
+   * @brief SMConstants The SM Constants used during the EWBG calculation
+   */
+  const ISMConstants SMConstants;
+
 public:
   /**
    * @brief CalculateEtaInterface Initialises the class with a config pair
    * @param config config.first sets the CalculateEtaInterface::method_transport
    * and second CalculateEtaInterface::bot_mass_flag
+   * @param smConstants The SM Constants. This should be the same as used by the
+   * parameter point used to calculate the SFOEWPT
    */
-  CalculateEtaInterface(const std::pair<std::vector<bool>, int> &config);
+  CalculateEtaInterface(const std::pair<std::vector<bool>, int> &config,
+                        const ISMConstants &smConstants);
 
   /**
    * Initialises the class member and sets the
@@ -120,17 +129,23 @@ public:
    * @param method_input Sets the CalculateEtaInterface::method_transport member
    * @param bot_mass_flag_in Sets the CalculateEtaInterface::bot_mass_flag
    * member
+   * @param smConstants The SM Constants. This should be the same as used by the
+   * parameter point used to calculate the SFOEWPT
    */
   CalculateEtaInterface(const std::vector<bool> &method_input,
-                        const int &bot_mass_flag_in);
+                        const int &bot_mass_flag_in,
+                        const ISMConstants &smConstants);
 
   /**
    * Initialises the class member and sets the
    * CalculateEtaInterface::method_transport and
    * CalculateEtaInterface::bot_mass_flag with the input given in the input file
    * @param file input file to get the settings
+   * @param smConstants The SM Constants. This should be the same as used by the
+   * parameter point used to calculate the SFOEWPT
    */
-  CalculateEtaInterface(const std::string &file);
+  CalculateEtaInterface(const std::string &file,
+                        const ISMConstants &smConstants);
 
   virtual ~CalculateEtaInterface();
 

--- a/include/BSMPT/baryo_calculation/Fluid_Type/bot_source.h
+++ b/include/BSMPT/baryo_calculation/Fluid_Type/bot_source.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2020  Philipp Basler, Margarete Mühlleitner and Jonas Müller
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,6 +38,7 @@ class bot_source : public gen_fluid
 {
 private:
 public:
+  bot_source(const ISMConstants &smConstants);
   /**
    * @brief operator () Needed for the numerical solution via boost.
    * @param omega Vector of all included (rescaled) chemical potentials

--- a/include/BSMPT/baryo_calculation/Fluid_Type/gen_func_fluid.h
+++ b/include/BSMPT/baryo_calculation/Fluid_Type/gen_func_fluid.h
@@ -237,6 +237,7 @@ double NIntegrate_kappa(const Calc_kappa_t &C_kap);
 class Calc_eta
 {
 private:
+  ISMConstants SMConstants;
   /**
    * @brief Temp Temperature
    */
@@ -255,6 +256,7 @@ private:
 
 public:
   double prefactor;
+  Calc_eta(const ISMConstants &smConstants);
   void set_class(std::vector<double> array_z,
                  std::vector<double> array_nL,
                  double Temp,
@@ -297,7 +299,10 @@ double Nintegrate_eta(const Calc_eta &C_eta,
 class gen_fluid
 {
 private:
+  const ISMConstants SMConstants;
+
 public:
+  gen_fluid(const ISMConstants &smConstants);
   int bot_mass_flag;
   int tau_mass_flag =
       1; // Changing to zero for massless tau leptons --> might cause problems!
@@ -394,9 +399,9 @@ public:
   double gprime = 0.36;
   double alphaS = 1. / 7;
   double alphaW = 1. / 30;
-  double mtop_0 = C_MassTop;
-  double mbot_0 = C_MassBottom;
-  double mtau_0 = C_MassTau;
+  double mtop_0{0};
+  double mbot_0{0};
+  double mtau_0{0};
 
   /**
    * @brief Dq Diffusion constant of quarks.

--- a/include/BSMPT/baryo_calculation/Fluid_Type/tau_source.h
+++ b/include/BSMPT/baryo_calculation/Fluid_Type/tau_source.h
@@ -2,7 +2,8 @@
 #define TAU_SOURCE_H
 
 // Copyright (C) 2020  Philipp Basler, Margarete Mühlleitner and Jonas Müller
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,6 +33,7 @@ class tau_source : public gen_fluid
 {
 private:
 public:
+  tau_source(const ISMConstants &smConstants);
   /**
    * @brief operator () Needed for the numerical solution via boost.
    * @param omega Vector of all included (rescaled) chemical potentials

--- a/include/BSMPT/baryo_calculation/Fluid_Type/top_source.h
+++ b/include/BSMPT/baryo_calculation/Fluid_Type/top_source.h
@@ -2,7 +2,8 @@
 #define TOP_SOURCE_H
 
 // Copyright (C) 2020  Philipp Basler, Margarete Mühlleitner and Jonas Müller
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,6 +33,7 @@ class top_source : public gen_fluid
 {
 private:
 public:
+  top_source(const ISMConstants &smConstants);
   /**
    * @brief operator () Needed for the numerical solution via boost.
    * @param omega Vector of all included (rescaled) chemical potentials

--- a/include/BSMPT/minimizer/MinimizePlane.h
+++ b/include/BSMPT/minimizer/MinimizePlane.h
@@ -1,4 +1,5 @@
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -119,6 +120,7 @@ struct PointerContainerMinPlane
  * @param Model Decides which model should be used through FChoose
  * @param par Inputparameters for the parameterpoint
  * @param parCT Counterterm parameters for the parameterpoint
+ * @param SMConstant The SM constants used by the parameter point
  * @param Temp Temperature at which the minimum should be calculated
  * @return MinimizePlaneReturn struct which has the minimum and the value of the
  * potential
@@ -130,6 +132,7 @@ MinimizePlane(const std::vector<double> &basepoint,
               const ModelID::ModelIDs &Model,
               const std::vector<double> &par,
               const std::vector<double> &parCT,
+              const ISMConstants &SMConstant,
               const double &Temp,
               const int &WhichMinimizer = WhichMinimizerDefault);
 /**

--- a/include/BSMPT/minimizer/Minimizer.h
+++ b/include/BSMPT/minimizer/Minimizer.h
@@ -168,6 +168,7 @@ PTFinder_gen_all(const std::shared_ptr<Class_Potential_Origin> &modelPointer,
  * @param Model Which Model to minimize
  * @param par parameters of the point
  * @param parCT counterterm parameters
+ * @param SMConstants The SM Constants used for the minimisation
  * @param Check Vector to safe the error flags during the minimization
  * @param start Starting point for the minimization
  * @param WhichMinimizer Which minimizers should be taken? 1 = CMAES, 2 = GSL, 4
@@ -178,6 +179,7 @@ std::vector<double>
 Minimize_gen_all_tree_level(const ModelID::ModelIDs &Model,
                             const std::vector<double> &par,
                             const std::vector<double> &parCT,
+                            const ISMConstants &SMConstants,
                             std::vector<double> &Check,
                             const std::vector<double> &start,
                             int WhichMinimizer     = WhichMinimizerDefault,

--- a/include/BSMPT/models/ClassPotentialC2HDM.h
+++ b/include/BSMPT/models/ClassPotentialC2HDM.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2018  Philipp Basler and Margarete Mühlleitner
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,7 +78,7 @@ namespace Models
 class Class_Potential_C2HDM : public Class_Potential_Origin
 {
 public:
-  Class_Potential_C2HDM();
+  Class_Potential_C2HDM(const ISMConstants &smConstants);
   virtual ~Class_Potential_C2HDM() override;
 
   bool UseHsmNotationInTripleHiggs = false;
@@ -88,7 +89,7 @@ public:
          Du1CT = 0, DRu3CT = 0;
   double DIL5CT = 0, DIu3CT = 0;
   double DT1 = 0, DT2 = 0, DT3 = 0, DTCharged = 0;
-  double DIL6CT=0;
+  double DIL6CT  = 0;
   double TanBeta = 0, C_CosBeta = 0, C_SinBeta = 0, C_CosBetaSquared = 0,
          C_SinBetaSquared = 0;
   double beta             = 0;
@@ -97,7 +98,7 @@ public:
   double CTempC1 = 0, CTempC2 = 0, CTempCS = 0;
   double R_Hh_1 = 0, R_Hh_2 = 0, R_Hh_3 = 0, R_Hl_1 = 0, R_Hl_2 = 0, R_Hl_3 = 0,
          R_Hsm_1 = 0, R_Hsm_2 = 0, R_Hsm_3 = 0;
-  
+
   void ReadAndSet(const std::string &linestr,
                   std::vector<double> &par) override;
   std::vector<std::string> addLegendCT() const override;

--- a/include/BSMPT/models/ClassPotentialCPintheDark.h
+++ b/include/BSMPT/models/ClassPotentialCPintheDark.h
@@ -83,7 +83,7 @@ namespace Models
 class Class_Potential_CPintheDark : public Class_Potential_Origin
 {
 public:
-  Class_Potential_CPintheDark();
+  Class_Potential_CPintheDark(const ISMConstants &smConstants);
   virtual ~Class_Potential_CPintheDark();
 
   // parameters of scalar potential

--- a/include/BSMPT/models/ClassPotentialCxSM.h
+++ b/include/BSMPT/models/ClassPotentialCxSM.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2020  Philipp Basler, Margarete Mühlleitner and Jonas Müller
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,8 +78,8 @@ public:
   double dmsq, dlambda, ddelta2, db2, dd2, dReb1, dImb1, dRea1, dIma1, dT1, dT2,
       dT3, dT4, dT5, dT6;
 
-  double g1 = C_gs;
-  double g2 = C_g;
+  double g1 = SMConstants.C_gs;
+  double g2 = SMConstants.C_g;
 
   double vh, vs, va;
 

--- a/include/BSMPT/models/ClassPotentialCxSM.h
+++ b/include/BSMPT/models/ClassPotentialCxSM.h
@@ -66,7 +66,7 @@ namespace Models
 class Class_CxSM : public Class_Potential_Origin
 {
 public:
-  Class_CxSM();
+  Class_CxSM(const ISMConstants &smConstants);
   virtual ~Class_CxSM();
 
   // Add here your parameters for the Lagrangian as well as for the counterterm

--- a/include/BSMPT/models/ClassPotentialOrigin.h
+++ b/include/BSMPT/models/ClassPotentialOrigin.h
@@ -523,6 +523,16 @@ public:
    * @return ModelID of the Model
    */
   ModelID::ModelIDs get_Model() const { return Model; }
+
+  /**
+   * @brief get_DebyeHiggs get the Debye corrections to the Higgs mass matrix
+   * @return
+   */
+  const std::vector<std::vector<double>> &get_DebyeHiggs() const
+  {
+    return DebyeHiggs;
+  }
+
   /**
    * @brief set_InputLineNumber
    * @param InputLineNumber_in value to set InputLineNumber
@@ -738,8 +748,11 @@ public:
    * Calculates the Debye corrections to the Higgs mass matrix.
    * If you can provide CalculateDebyeSimplified() with the Matrix as this will
    * reduce the runtime.
+   * @param forceCalculation Forces the caclulation, even if the model
+   * implements a simplified version. The simplified calculation will be
+   * skipped.
    */
-  void CalculateDebye();
+  void CalculateDebye(bool forceCalculation = false);
   /**
    * Calculates the Debye corrections to the gauge sector. By using
    * CalculateDebyeGaugeSimplified() the runtime can be reduced.

--- a/include/BSMPT/models/ClassPotentialOrigin.h
+++ b/include/BSMPT/models/ClassPotentialOrigin.h
@@ -55,6 +55,12 @@ const double C_CWcbHiggs = 1.5;
  */
 class Class_Potential_Origin
 {
+public:
+  /**
+   * @brief SMConstants The SM constants used by the model
+   */
+  const ISMConstants SMConstants;
+
 protected:
   /**
    * @brief UseTreeLevel Enforces VEff to only use the tree-level potential
@@ -64,7 +70,7 @@ protected:
   /**
    * MSBar renormalization scale
    */
-  double scale = C_vev0;
+  double scale;
 
   /**
    * Number of Lagrange parameters in the Higgs Tree-Level potential
@@ -383,7 +389,7 @@ protected:
   std::vector<std::size_t> VevOrder;
 
 public:
-  Class_Potential_Origin();
+  Class_Potential_Origin(const ISMConstants &smConstants = GetSMConstants());
   virtual ~Class_Potential_Origin();
 
   /**

--- a/include/BSMPT/models/ClassPotentialOrigin.h
+++ b/include/BSMPT/models/ClassPotentialOrigin.h
@@ -389,7 +389,7 @@ protected:
   std::vector<std::size_t> VevOrder;
 
 public:
-  Class_Potential_Origin(const ISMConstants &smConstants = GetSMConstants());
+  Class_Potential_Origin(const ISMConstants &smConstants);
   virtual ~Class_Potential_Origin();
 
   /**

--- a/include/BSMPT/models/ClassPotentialR2HDM.h
+++ b/include/BSMPT/models/ClassPotentialR2HDM.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2018  Philipp Basler and Margarete Mühlleitner
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -75,7 +76,7 @@ namespace Models
 class Class_Potential_R2HDM : public Class_Potential_Origin
 {
 public:
-  Class_Potential_R2HDM();
+  Class_Potential_R2HDM(const ISMConstants &smConstants);
   virtual ~Class_Potential_R2HDM();
 
   double L1 = 0, L2 = 0, L3 = 0, L4 = 0, RL5 = 0, RealMMix = 0, u1 = 0, u2 = 0;

--- a/include/BSMPT/models/ClassPotentialRN2HDM.h
+++ b/include/BSMPT/models/ClassPotentialRN2HDM.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2018  Philipp Basler and Margarete Mühlleitner
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -79,7 +80,7 @@ namespace Models
 class Class_Potential_RN2HDM : public Class_Potential_Origin
 {
 public:
-  Class_Potential_RN2HDM();
+  Class_Potential_RN2HDM(const ISMConstants &smConstants);
   virtual ~Class_Potential_RN2HDM();
 
   double L1 = 0, L2 = 0, L3 = 0, L4 = 0, RL5 = 0, RealMMix = 0, u1 = 0, u2 = 0;

--- a/include/BSMPT/models/ClassTemplate.h
+++ b/include/BSMPT/models/ClassTemplate.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2018  Philipp Basler and Margarete Mühlleitner
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,7 +26,7 @@ namespace Models
 class Class_Template : public Class_Potential_Origin
 {
 public:
-  Class_Template();
+  Class_Template(const ISMConstants &smConstants);
   virtual ~Class_Template();
 
   // Add here your parameters for the Lagrangian as well as for the counterterm

--- a/include/BSMPT/models/IncludeAllModels.h
+++ b/include/BSMPT/models/IncludeAllModels.h
@@ -20,6 +20,7 @@
  */
 namespace BSMPT
 {
+struct ISMConstants;
 class Class_Potential_Origin;
 namespace ModelID
 {
@@ -69,7 +70,8 @@ std::unordered_map<ModelIDs, std::string> InvertModelNames();
  * @throw Runtime error if an invalid model was given into choice
  */
 
-std::unique_ptr<Class_Potential_Origin> FChoose(ModelIDs choice);
+std::unique_ptr<Class_Potential_Origin>
+FChoose(ModelIDs choice, const ISMConstants &smConstants);
 
 /**
  *

--- a/include/BSMPT/models/ModelTestfunctions.h
+++ b/include/BSMPT/models/ModelTestfunctions.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include <BSMPT/models/SMparam.h>
+
 namespace BSMPT
 {
 class Class_Potential_Origin;
@@ -43,7 +45,7 @@ CheckCTConditionsSecondDerivative(const Class_Potential_Origin &point);
 TestResults CheckCTIdentities(const Class_Potential_Origin &point);
 TestResults CheckCTNumber(const Class_Potential_Origin &point);
 
-TestResults CheckCKMUnitarity(const ISMConstants SMConstants);
+TestResults CheckCKMUnitarity(const ISMConstants &SMConstants);
 TestResults CheckSymmetricTensorScalarSecond(
     const std::vector<std::vector<double>> &Tensor);
 TestResults CheckSymmetricTensorScalarThird(

--- a/include/BSMPT/models/ModelTestfunctions.h
+++ b/include/BSMPT/models/ModelTestfunctions.h
@@ -43,7 +43,7 @@ CheckCTConditionsSecondDerivative(const Class_Potential_Origin &point);
 TestResults CheckCTIdentities(const Class_Potential_Origin &point);
 TestResults CheckCTNumber(const Class_Potential_Origin &point);
 
-TestResults CheckCKMUnitarity();
+TestResults CheckCKMUnitarity(const ISMConstants SMConstants);
 TestResults CheckSymmetricTensorScalarSecond(
     const std::vector<std::vector<double>> &Tensor);
 TestResults CheckSymmetricTensorScalarThird(

--- a/include/BSMPT/models/SMparam.h
+++ b/include/BSMPT/models/SMparam.h
@@ -26,193 +26,193 @@ struct ISMConstants
    * @brief The lambda parameter in the Wolfenstein parametrisation of the
    * CKM-Matrix LHCHXSWG-INT-2015-006
    */
-  double C_Wolfenstein_lambda;
+  double C_Wolfenstein_lambda{0};
 
   /**
    * @brief The A parameter in the Wolfenstein parametrisation of the CKM-Matrix
    * LHCHXSWG-INT-2015-006
    */
-  double C_Wolfenstein_A;
+  double C_Wolfenstein_A{0};
 
   /**
    * @brief The rho parameter in the Wolfenstein parametrisation of the
    * CKM-Matrix LHCHXSWG-INT-2015-006
    */
-  double C_Wolfenstein_rho;
+  double C_Wolfenstein_rho{0};
   /**
    * @brief The eta parameter in the Wolfenstein parametrisation of the
    * CKM-Matrix LHCHXSWG-INT-2015-006
    */
-  double C_Wolfenstein_eta;
+  double C_Wolfenstein_eta{0};
 
   /**
    * @brief The theta_12 mixing angle in the CKM matrix calculated by the
    * Wolfenstein parameters
    */
-  double theta12;
+  double theta12{0};
   /**
    * @brief The theta_23 mixing angle in the CKM matrix calculated by the
    * Wolfenstein parameters
    */
-  double theta23;
+  double theta23{0};
   /**
    * @brief The CP-violating angle in the CKM matrix calculated by the
    * Wolfenstein parameters
    */
-  double delta;
+  double delta{0};
   /**
    * @brief The theta_13 mixing angle in the CKM matrix calculated by the
    * Wolfenstein parameters
    */
-  double theta13;
+  double theta13{0};
 
   /**
    * @brief ud element of the CKM matrix
    */
-  std::complex<double> C_Vud;
+  std::complex<double> C_Vud{0, 0};
   /**
    * @brief us element of the CKM matrix
    */
-  std::complex<double> C_Vus;
+  std::complex<double> C_Vus{0, 0};
   /**
    * @brief ub element of the CKM matrix
    */
-  std::complex<double> C_Vub;
+  std::complex<double> C_Vub{0, 0};
 
   /**
    * @brief cd element of the CKM matrix
    */
-  std::complex<double> C_Vcd;
+  std::complex<double> C_Vcd{0, 0};
   /**
    * @brief cs element of the CKM matrix
    */
-  std::complex<double> C_Vcs;
+  std::complex<double> C_Vcs{0, 0};
   /**
    * @brief cb element of the CKM matrix
    */
-  std::complex<double> C_Vcb;
+  std::complex<double> C_Vcb{0, 0};
 
   /**
    * @brief td element of the CKM matrix
    */
-  std::complex<double> C_Vtd;
+  std::complex<double> C_Vtd{0, 0};
   /**
    * @brief ts element of the CKM matrix
    */
-  std::complex<double> C_Vts;
+  std::complex<double> C_Vts{0, 0};
   /**
    * @brief tb element of the CKM matrix
    */
-  std::complex<double> C_Vtb;
+  std::complex<double> C_Vtb{0, 0};
 
   /**
    * @brief Mass of the W-Boson
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassW;
+  double C_MassW{0};
   /**
    * @brief Mass of the Z-Boson
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassZ;
+  double C_MassZ{0};
   /**
    * @brief Mass of the Higgs Boson
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassSMHiggs;
+  double C_MassSMHiggs{0};
 
   /**
    * @brief Mass of the up quark
    * Unit: GeV
    * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
    */
-  double C_MassUp;
+  double C_MassUp{0};
   /**
    * @brief Mass of the down quark
    * Unit: GeV
    * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
    */
-  double C_MassDown;
+  double C_MassDown{0};
   /**
    * @brief Mass of the strange quark
    * Unit: GeV
    * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
    */
-  double C_MassStrange;
+  double C_MassStrange{0};
   /**
    * @brief Mass of the top quark in the OS Scheme
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassTop;
+  double C_MassTop{0};
   /**
    * @brief Mass of the charm quark in the OS Scheme
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassCharm;
+  double C_MassCharm{0};
   /**
    * @brief Mass of the bottom quark in the OS Scheme
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassBottom;
+  double C_MassBottom{0};
 
   /**
    * @brief Mass of the tau lepton
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassTau;
+  double C_MassTau{0};
   /**
    * @brief Mass of the muon
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassMu;
+  double C_MassMu{0};
   /**
    * @brief Mass of the electron
    * Unit: GeV
    * LHCHXSWG-INT-2015-006
    */
-  double C_MassElectron;
+  double C_MassElectron{0};
 
   /**
    * @brief Fermi constant
    * Unit: GeV^{-2}
    * LHCHXSWG-INT-2015-006
    */
-  double C_GF;
+  double C_GF{0};
 
   /**
    * @brief sin^2(theta_Weinberg) derived from the W- and Z-Boson masses
    */
-  double C_sinsquaredWeinberg;
+  double C_sinsquaredWeinberg{0};
 
   /**
    * @brief Vacuum expectation value of the SM derived through the Fermi
    * constant
    */
-  double C_vev0;
+  double C_vev0{0};
   /**
    * @brief gauge coupling of the U(2)_L with the SM Higgs doublett, derived
    * through the W-Boson mass and the SM VEV Unit: GeV
    */
-  double C_g;
+  double C_g{0};
   /**
    * @brief gauge coupling of the U(1) with the SM Higgs doublett, derived
    * through the W- and Z-Boson masses and the SM VEV
    */
-  double C_gs;
+  double C_gs{0};
 
   /**
    * @brief Trilinear coupling between three SM Higgs Boson, calculated as the
    * third derivative of the SM Higgs Potential Unit: GeV
    */
-  double C_SMTriHiggs;
+  double C_SMTriHiggs{0};
 };
 
 /**

--- a/include/BSMPT/models/SMparam.h
+++ b/include/BSMPT/models/SMparam.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2018  Philipp Basler and Margarete Mühlleitner
-// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas Müller
+// SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas
+// Müller
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,244 +18,214 @@ namespace BSMPT
 {
 
 /**
+ * @brief The ISMConstants struct containing all necessary SM constants.
+ */
+struct ISMConstants
+{
+  /**
+   * @brief The lambda parameter in the Wolfenstein parametrisation of the
+   * CKM-Matrix LHCHXSWG-INT-2015-006
+   */
+  double C_Wolfenstein_lambda;
+
+  /**
+   * @brief The A parameter in the Wolfenstein parametrisation of the CKM-Matrix
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_Wolfenstein_A;
+
+  /**
+   * @brief The rho parameter in the Wolfenstein parametrisation of the
+   * CKM-Matrix LHCHXSWG-INT-2015-006
+   */
+  double C_Wolfenstein_rho;
+  /**
+   * @brief The eta parameter in the Wolfenstein parametrisation of the
+   * CKM-Matrix LHCHXSWG-INT-2015-006
+   */
+  double C_Wolfenstein_eta;
+
+  /**
+   * @brief The theta_12 mixing angle in the CKM matrix calculated by the
+   * Wolfenstein parameters
+   */
+  double theta12;
+  /**
+   * @brief The theta_23 mixing angle in the CKM matrix calculated by the
+   * Wolfenstein parameters
+   */
+  double theta23;
+  /**
+   * @brief The CP-violating angle in the CKM matrix calculated by the
+   * Wolfenstein parameters
+   */
+  double delta;
+  /**
+   * @brief The theta_13 mixing angle in the CKM matrix calculated by the
+   * Wolfenstein parameters
+   */
+  double theta13;
+
+  /**
+   * @brief ud element of the CKM matrix
+   */
+  std::complex<double> C_Vud;
+  /**
+   * @brief us element of the CKM matrix
+   */
+  std::complex<double> C_Vus;
+  /**
+   * @brief ub element of the CKM matrix
+   */
+  std::complex<double> C_Vub;
+
+  /**
+   * @brief cd element of the CKM matrix
+   */
+  std::complex<double> C_Vcd;
+  /**
+   * @brief cs element of the CKM matrix
+   */
+  std::complex<double> C_Vcs;
+  /**
+   * @brief cb element of the CKM matrix
+   */
+  std::complex<double> C_Vcb;
+
+  /**
+   * @brief td element of the CKM matrix
+   */
+  std::complex<double> C_Vtd;
+  /**
+   * @brief ts element of the CKM matrix
+   */
+  std::complex<double> C_Vts;
+  /**
+   * @brief tb element of the CKM matrix
+   */
+  std::complex<double> C_Vtb;
+
+  /**
+   * @brief Mass of the W-Boson
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassW;
+  /**
+   * @brief Mass of the Z-Boson
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassZ;
+  /**
+   * @brief Mass of the Higgs Boson
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassSMHiggs;
+
+  /**
+   * @brief Mass of the up quark
+   * Unit: GeV
+   * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
+   */
+  double C_MassUp;
+  /**
+   * @brief Mass of the down quark
+   * Unit: GeV
+   * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
+   */
+  double C_MassDown;
+  /**
+   * @brief Mass of the strange quark
+   * Unit: GeV
+   * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
+   */
+  double C_MassStrange;
+  /**
+   * @brief Mass of the top quark in the OS Scheme
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassTop;
+  /**
+   * @brief Mass of the charm quark in the OS Scheme
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassCharm;
+  /**
+   * @brief Mass of the bottom quark in the OS Scheme
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassBottom;
+
+  /**
+   * @brief Mass of the tau lepton
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassTau;
+  /**
+   * @brief Mass of the muon
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassMu;
+  /**
+   * @brief Mass of the electron
+   * Unit: GeV
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_MassElectron;
+
+  /**
+   * @brief Fermi constant
+   * Unit: GeV^{-2}
+   * LHCHXSWG-INT-2015-006
+   */
+  double C_GF;
+
+  /**
+   * @brief sin^2(theta_Weinberg) derived from the W- and Z-Boson masses
+   */
+  double C_sinsquaredWeinberg;
+
+  /**
+   * @brief Vacuum expectation value of the SM derived through the Fermi
+   * constant
+   */
+  double C_vev0;
+  /**
+   * @brief gauge coupling of the U(2)_L with the SM Higgs doublett, derived
+   * through the W-Boson mass and the SM VEV Unit: GeV
+   */
+  double C_g;
+  /**
+   * @brief gauge coupling of the U(1) with the SM Higgs doublett, derived
+   * through the W- and Z-Boson masses and the SM VEV
+   */
+  double C_gs;
+
+  /**
+   * @brief Trilinear coupling between three SM Higgs Boson, calculated as the
+   * third derivative of the SM Higgs Potential Unit: GeV
+   */
+  double C_SMTriHiggs;
+};
+
+/**
  * @brief imaginary number i
  */
 const std::complex<double> II(0, 1);
 
-// CKM Matrix
-
-// const double C_Vts = 0.0404;
-// const double C_Vtd = 0.00867;
-// const double C_Vtb = std::sqrt(1-C_Vts*C_Vts - C_Vtd*C_Vtd); //0.9991;
-// const double C_Vcb = 0.0412;
-// const double C_Vcd = 0.22520;
-// const double C_Vcs = std::sqrt(1-C_Vcb*C_Vcb-C_Vcd*C_Vcd);//0.97344;
-// const double C_Vub = 0.00351;
-// const double C_Vus = 0.22534;
-// const double C_Vud = std::sqrt(1-C_Vub*C_Vub-C_Vus*C_Vus);//0.97427;
-
-// CKM Matrix as unitary
-
-// const std::complex<double> C_Vts=0;
-// const std::complex<double> C_Vtd = 0;
-// const std::complex<double> C_Vtb = 1; //0.9991;
-// const std::complex<double> C_Vcb = 0;
-// const std::complex<double> C_Vcd = 0;
-// const std::complex<double> C_Vcs = 1;//0.97344;
-// const std::complex<double> C_Vub = 0;
-// const std::complex<double> C_Vus = 0;
-// const std::complex<double> C_Vud = 1; //0.97427;
-
-/* Here is an example of the CKM Matrix given by the standard parameters. The
- * elements V11, V23 and V33 are real in this parametrisation and are calculated
- * by the other elements and the unitarity conditions. If the unitarity at
- * numerical precision is not given you will end up with massive charged
- * Goldstone bosons
- */
-
 /**
- * @brief The lambda parameter in the Wolfenstein parametrisation of the
- * CKM-Matrix LHCHXSWG-INT-2015-006
+ * @brief GetSMConstants returns a set of SM contants as indicated by the
+ * sources described for each parameter.
+ * @return The SM Constants used by default in BSMPT
  */
-const double C_Wolfenstein_lambda = 0.22537;
-/**
- * @brief The A parameter in the Wolfenstein parametrisation of the CKM-Matrix
- * LHCHXSWG-INT-2015-006
- */
-const double C_Wolfenstein_A = 0.814;
-/**
- * @brief The rho parameter in the Wolfenstein parametrisation of the CKM-Matrix
- * LHCHXSWG-INT-2015-006
- */
-const double C_Wolfenstein_rho = 0.117;
-/**
- * @brief The eta parameter in the Wolfenstein parametrisation of the CKM-Matrix
- * LHCHXSWG-INT-2015-006
- */
-const double C_Wolfenstein_eta = 0.353;
-
-/**
- * @brief The theta_12 mixing angle in the CKM matrix calculated by the
- * Wolfenstein parameters
- */
-const double theta12 = std::asin(C_Wolfenstein_lambda);
-/**
- * @brief The theta_23 mixing angle in the CKM matrix calculated by the
- * Wolfenstein parameters
- */
-const double theta23 =
-    std::asin(C_Wolfenstein_A * std::pow(C_Wolfenstein_lambda, 2));
-/**
- * @brief The CP-violating angle in the CKM matrix calculated by the Wolfenstein
- * parameters
- */
-const double delta =
-    std::arg(C_Wolfenstein_A * std::pow(C_Wolfenstein_lambda, 3) *
-             (C_Wolfenstein_rho + II * C_Wolfenstein_eta));
-/**
- * @brief The theta_13 mixing angle in the CKM matrix calculated by the
- * Wolfenstein parameters
- */
-const double theta13 =
-    std::asin(std::abs(C_Wolfenstein_A * std::pow(C_Wolfenstein_lambda, 3) *
-                       (C_Wolfenstein_rho + II * C_Wolfenstein_eta)));
-
-/**
- * @brief ud element of the CKM matrix
- */
-const std::complex<double> C_Vud = std::cos(theta12) * std::cos(theta13);
-/**
- * @brief us element of the CKM matrix
- */
-const std::complex<double> C_Vus = std::sin(theta12) * std::cos(theta13);
-/**
- * @brief ub element of the CKM matrix
- */
-const std::complex<double> C_Vub = std::sin(theta13) * std::exp(-delta * II);
-
-/**
- * @brief cd element of the CKM matrix
- */
-const std::complex<double> C_Vcd = -std::sin(theta12) * std::cos(theta23) -
-                                   std::cos(theta12) * std::sin(theta23) *
-                                       std::sin(theta13) * std::exp(II * delta);
-/**
- * @brief cs element of the CKM matrix
- */
-const std::complex<double> C_Vcs = std::cos(theta12) * std::cos(theta23) -
-                                   std::sin(theta12) * std::sin(theta23) *
-                                       std::sin(theta13) * std::exp(II * delta);
-/**
- * @brief cb element of the CKM matrix
- */
-const std::complex<double> C_Vcb = std::sin(theta23) * std::cos(theta13);
-
-/**
- * @brief td element of the CKM matrix
- */
-const std::complex<double> C_Vtd = std::sin(theta12) * std::sin(theta23) -
-                                   std::cos(theta12) * std::cos(theta23) *
-                                       std::sin(theta13) * std::exp(II * delta);
-/**
- * @brief ts element of the CKM matrix
- */
-const std::complex<double> C_Vts = -std::cos(theta12) * std::sin(theta23) -
-                                   std::sin(theta12) * std::cos(theta23) *
-                                       std::sin(theta13) * std::exp(II * delta);
-/**
- * @brief tb element of the CKM matrix
- */
-const std::complex<double> C_Vtb = std::cos(theta23) * std::cos(theta13);
-
-/**
- * @brief Mass of the W-Boson
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassW = 80.385;
-/**
- * @brief Mass of the Z-Boson
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassZ = 91.1876;
-/**
- * @brief Mass of the Higgs Boson
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassSMHiggs = 125.09;
-
-/**
- * @brief Mass of the up quark
- * Unit: GeV
- * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
- */
-const double C_MassUp = 0.1;
-/**
- * @brief Mass of the down quark
- * Unit: GeV
- * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
- */
-const double C_MassDown = 0.1;
-/**
- * @brief Mass of the strange quark
- * Unit: GeV
- * https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWG
- */
-const double C_MassStrange = 0.1;
-/**
- * @brief Mass of the top quark in the OS Scheme
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassTop = 172.5;
-/**
- * @brief Mass of the charm quark in the OS Scheme
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassCharm = 1.51;
-/**
- * @brief Mass of the bottom quark in the OS Scheme
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassBottom = 4.92;
-
-/**
- * @brief Mass of the tau lepton
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassTau = 1.77682;
-/**
- * @brief Mass of the muon
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassMu = 0.1056583715;
-/**
- * @brief Mass of the electron
- * Unit: GeV
- * LHCHXSWG-INT-2015-006
- */
-const double C_MassElectron = 0.510998928 * std::pow(10.0, -3.0);
-
-/**
- * @brief Fermi constant
- * Unit: GeV^{-2}
- * LHCHXSWG-INT-2015-006
- */
-const double C_GF = 1.1663787 * 1e-5;
-
-/**
- * @brief sin^2(theta_Weinberg) derived from the W- and Z-Boson masses
- */
-const double C_sinsquaredWeinberg =
-    1 - (C_MassW * C_MassW) / (C_MassZ * C_MassZ);
-
-/**
- * @brief Vacuum expectation value of the SM derived through the Fermi constant
- */
-const double C_vev0 = std::sqrt(1 / std::sqrt(2) * 1 / C_GF);
-/**
- * @brief gauge coupling of the U(2)_L with the SM Higgs doublett, derived
- * through the W-Boson mass and the SM VEV Unit: GeV
- */
-const double C_g = 2 * C_MassW / C_vev0;
-/**
- * @brief gauge coupling of the U(1) with the SM Higgs doublett, derived through
- * the W- and Z-Boson masses and the SM VEV
- */
-const double C_gs =
-    2 * std::sqrt(std::pow(C_MassZ, 2) - std::pow(C_MassW, 2)) / C_vev0;
-
-/**
- * @brief Trilinear coupling between three SM Higgs Boson, calculated as the
- * third derivative of the SM Higgs Potential Unit: GeV
- */
-const double C_SMTriHiggs = 3 * C_MassSMHiggs * C_MassSMHiggs / (C_vev0);
+const ISMConstants GetSMConstants();
 
 } // namespace BSMPT
 

--- a/src/baryo_calculation/CalculateEtaInterface.cpp
+++ b/src/baryo_calculation/CalculateEtaInterface.cpp
@@ -95,9 +95,13 @@ CalculateEtaInterface::ReadConfigFile(const std::string &file) const
 }
 
 CalculateEtaInterface::CalculateEtaInterface(
-    const std::pair<std::vector<bool>, int> &config)
+    const std::pair<std::vector<bool>, int> &config,
+    const ISMConstants &smConstants)
     : method_transport{config.first}
+    , C_eta(smConstants)
     , bot_mass_flag{config.second}
+    , SMConstants{smConstants}
+
 {
   if (config.first.size() != 5)
   {
@@ -110,15 +114,18 @@ CalculateEtaInterface::CalculateEtaInterface(
   }
 }
 
-CalculateEtaInterface::CalculateEtaInterface(const std::string &file)
-    : CalculateEtaInterface(ReadConfigFile(file))
+CalculateEtaInterface::CalculateEtaInterface(const std::string &file,
+                                             const ISMConstants &smConstants)
+    : CalculateEtaInterface(ReadConfigFile(file), smConstants)
 {
 }
 
 CalculateEtaInterface::CalculateEtaInterface(
     const std::vector<bool> &method_input,
-    const int &bot_mass_flag_in)
-    : CalculateEtaInterface(std::make_pair(method_input, bot_mass_flag_in))
+    const int &bot_mass_flag_in,
+    const ISMConstants &smConstants)
+    : CalculateEtaInterface(std::make_pair(method_input, bot_mass_flag_in),
+                            smConstants)
 {
 }
 
@@ -235,7 +242,7 @@ std::vector<double> CalculateEtaInterface::CalcEta()
   if (method_transport.at(0))
   {
     GSL_integration_mubl_container.set_transport_method(TransportMethod::top);
-    top_source C_top;
+    top_source C_top(SMConstants);
     C_top.set_class(bot_mass_flag,
                     GSL_integration_mubl_container,
                     Calc_Gam_inp,
@@ -250,7 +257,7 @@ std::vector<double> CalculateEtaInterface::CalcEta()
   {
     GSL_integration_mubl_container.set_transport_method(
         TransportMethod::bottom);
-    bot_source C_bot;
+    bot_source C_bot(SMConstants);
     C_bot.set_class(bot_mass_flag,
                     GSL_integration_mubl_container,
                     Calc_Gam_inp,
@@ -264,7 +271,7 @@ std::vector<double> CalculateEtaInterface::CalcEta()
   if (method_transport.at(2))
   {
     GSL_integration_mubl_container.set_transport_method(TransportMethod::tau);
-    tau_source C_tau;
+    tau_source C_tau(SMConstants);
     C_tau.set_class(bot_mass_flag,
                     GSL_integration_mubl_container,
                     Calc_Gam_inp,

--- a/src/baryo_calculation/Fluid_Type/bot_source.cpp
+++ b/src/baryo_calculation/Fluid_Type/bot_source.cpp
@@ -19,6 +19,10 @@ namespace Baryo
 typedef runge_kutta_cash_karp54<state_type> error_stepper_type;
 typedef controlled_runge_kutta<error_stepper_type> controlled_stepper_type;
 
+bot_source::bot_source(const ISMConstants &smConstants) : gen_fluid(smConstants)
+{
+}
+
 void bot_source::operator()(const state_type &omega,
                             state_type &domega,
                             const double z)

--- a/src/baryo_calculation/Fluid_Type/gen_func_fluid.cpp
+++ b/src/baryo_calculation/Fluid_Type/gen_func_fluid.cpp
@@ -281,11 +281,17 @@ void Calc_eta::operator()(const state_type &eta,
             std::exp(exponent_prefactor *
                      z); // prefactor is not used here for numerical stability
 }
+
+Calc_eta::Calc_eta(const ISMConstants &smConstants) : SMConstants{smConstants}
+{
+}
+
 void Calc_eta::set_class(std::vector<double> array_z_in,
                          std::vector<double> array_nL_in,
                          double Temp_in,
                          double vw_in)
 {
+
   Calc_eta::array_z  = array_z_in;
   Calc_eta::array_nL = array_nL_in;
   Calc_eta::Temp     = Temp_in;
@@ -383,6 +389,14 @@ double Nintegrate_eta(const Calc_eta &C_eta,
   if (std::isnan(eta[0]) or std::isnan(C_eta.prefactor))
     throw std::runtime_error("NaN in Nintegrate_eta");
   return C_eta.prefactor * eta[0];
+}
+
+gen_fluid::gen_fluid(const ISMConstants &smConstants)
+    : SMConstants{smConstants}
+    , mtop_0{smConstants.C_MassTop}
+    , mbot_0{smConstants.C_MassBottom}
+    , mtau_0{smConstants.C_MassTau}
+{
 }
 
 void gen_fluid::top_func(double z,
@@ -588,12 +602,12 @@ void gen_fluid::set_class(const int bottom_mass_inp,
   gen_fluid::Dtau   = 100. / Temp;
   double sinbeta    = std::sin(std::atan(tanbeta));
   double cosbeta    = std::cos(std::atan(tanbeta));
-  gen_fluid::yuk_q  = std::sqrt(2) * mtop_0 / (C_vev0 * sinbeta);
+  gen_fluid::yuk_q  = std::sqrt(2) * mtop_0 / (SMConstants.C_vev0 * sinbeta);
   gen_fluid::Gam_SS = 14 * std::pow(alphaS, 4) * Temp;
 
   double yuk_t = 0, yuk_b = 0, yuk_tau = 0;
   // top thermal mass
-  yuk_t              = std::sqrt(2) * mtop_0 / (C_vev0 * sinbeta);
+  yuk_t              = std::sqrt(2) * mtop_0 / (SMConstants.C_vev0 * sinbeta);
   auto top_thermal   = Calc_ThermalMass_q(yuk_t, Temp);
   msqrt_thermal_top  = top_thermal.first;
   dmsqrt_thermal_top = top_thermal.second;
@@ -601,24 +615,24 @@ void gen_fluid::set_class(const int bottom_mass_inp,
   if (Yuk_Type == 1)
   {
     // bot&tau thermal mass
-    yuk_b              = std::sqrt(2) * mbot_0 / (C_vev0 * sinbeta);
+    yuk_b              = std::sqrt(2) * mbot_0 / (SMConstants.C_vev0 * sinbeta);
     auto bot_thermal   = Calc_ThermalMass_q(yuk_b, Temp);
     msqrt_thermal_bot  = bot_thermal.first;
     dmsqrt_thermal_bot = bot_thermal.second;
 
-    yuk_tau            = std::sqrt(2) * mtau_0 / (C_vev0 * sinbeta);
+    yuk_tau            = std::sqrt(2) * mtau_0 / (SMConstants.C_vev0 * sinbeta);
     auto tau_thermal   = Calc_ThermalMass_l(yuk_tau, Temp);
     msqrt_thermal_tau  = tau_thermal.first;
     dmsqrt_thermal_tau = tau_thermal.second;
   }
   if (Yuk_Type == 2)
   {
-    yuk_b              = std::sqrt(2) * mbot_0 / (C_vev0 * cosbeta);
+    yuk_b              = std::sqrt(2) * mbot_0 / (SMConstants.C_vev0 * cosbeta);
     auto bot_thermal   = Calc_ThermalMass_q(yuk_b, Temp);
     msqrt_thermal_bot  = bot_thermal.first;
     dmsqrt_thermal_bot = bot_thermal.second;
 
-    yuk_tau            = std::sqrt(2) * mtau_0 / (C_vev0 * cosbeta);
+    yuk_tau            = std::sqrt(2) * mtau_0 / (SMConstants.C_vev0 * cosbeta);
     auto tau_thermal   = Calc_ThermalMass_l(yuk_tau, Temp);
     msqrt_thermal_tau  = tau_thermal.first;
     dmsqrt_thermal_tau = tau_thermal.second;

--- a/src/baryo_calculation/Fluid_Type/tau_source.cpp
+++ b/src/baryo_calculation/Fluid_Type/tau_source.cpp
@@ -19,6 +19,10 @@ namespace Baryo
 typedef runge_kutta_cash_karp54<state_type> error_stepper_type;
 typedef controlled_runge_kutta<error_stepper_type> controlled_stepper_type;
 
+tau_source::tau_source(const ISMConstants &smConstants) : gen_fluid(smConstants)
+{
+}
+
 void tau_source::operator()(const state_type &omega,
                             state_type &domega,
                             const double z)

--- a/src/baryo_calculation/Fluid_Type/top_source.cpp
+++ b/src/baryo_calculation/Fluid_Type/top_source.cpp
@@ -18,6 +18,10 @@ namespace Baryo
 typedef runge_kutta_cash_karp54<state_type> error_stepper_type;
 typedef controlled_runge_kutta<error_stepper_type> controlled_stepper_type;
 
+top_source::top_source(const ISMConstants &smConstants) : gen_fluid(smConstants)
+{
+}
+
 double top_source::Calc_nL(double z_start, double z_end) const
 {
   /*

--- a/src/minimizer/MinimizePlane.cpp
+++ b/src/minimizer/MinimizePlane.cpp
@@ -85,11 +85,12 @@ MinimizePlaneReturn MinimizePlane(const std::vector<double> &basepoint,
                                   const ModelID::ModelIDs &Model,
                                   const std::vector<double> &par,
                                   const std::vector<double> &parCT,
+                                  const ISMConstants &SMConstant,
                                   const double &Temp,
                                   const int &WhichMinimizer)
 {
   std::shared_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(Model);
+      ModelID::FChoose(Model, SMConstant);
   modelPointer->set_All(par, parCT);
   return MinimizePlane(
       basepoint, VEVSymmetric, VEVBroken, modelPointer, Temp, WhichMinimizer);

--- a/src/minimizer/Minimizer.cpp
+++ b/src/minimizer/Minimizer.cpp
@@ -415,13 +415,14 @@ std::vector<double>
 Minimize_gen_all_tree_level(const ModelID::ModelIDs &Model,
                             const std::vector<double> &par,
                             const std::vector<double> &parCT,
+                            const ISMConstants &SMConstants,
                             std::vector<double> &Check,
                             const std::vector<double> &start,
                             int WhichMinimizer,
                             bool UseMultithreading)
 {
   std::shared_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(Model);
+      ModelID::FChoose(Model, SMConstants);
   modelPointer->set_All(par, parCT);
   modelPointer->SetUseTreeLevel(true);
   auto sol = Minimize_gen_all(

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(Models ${header} ${src})
 target_link_libraries(Models PUBLIC GSL::gsl Eigen3::Eigen Minimizer
                                     ThermalFunctions Utility)
 target_include_directories(Models PUBLIC ${BSMPT_SOURCE_DIR}/include)
-target_compile_features(Models PUBLIC cxx_std_14)
+target_compile_features(Models PUBLIC cxx_std_17)
 
 # Include code-coverage settings: target_link_libraries(Models PUBLIC
 # coverage_config)

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -18,6 +18,7 @@ set(header
     ${header_path}/ClassTemplate.h)
 
 set(src
+    SMParam.cpp
     ModelTestfunctions.cpp
     IncludeAllModels.cpp
     ClassPotentialOrigin.cpp

--- a/src/models/ClassPotentialC2HDM.cpp
+++ b/src/models/ClassPotentialC2HDM.cpp
@@ -218,7 +218,7 @@ void Class_Potential_C2HDM::set_gen(const std::vector<double> &p)
 {
 
   //	double *p = (double *)par;
-  scale            = C_vev0;
+  scale            = SMConstants.C_vev0;
   L1               = p[0];
   L2               = p[1];
   L3               = p[2];
@@ -235,28 +235,38 @@ void Class_Potential_C2HDM::set_gen(const std::vector<double> &p)
   C_SinBeta        = sqrt(C_SinBetaSquared);
 
   u1 = RealMMix * TanBeta -
-       C_vev0 * C_vev0 * C_SinBetaSquared * (L4 + RL5 + L3) / 0.2e1 -
-       C_vev0 * C_vev0 * C_CosBetaSquared * L1 / 0.2e1;
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBetaSquared *
+           (L4 + RL5 + L3) / 0.2e1 -
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_CosBetaSquared * L1 / 0.2e1;
   u2 = RealMMix * 1.0 / TanBeta -
-       C_vev0 * C_vev0 * C_CosBetaSquared * (L4 + RL5 + L3) / 0.2e1 -
-       C_vev0 * C_vev0 * C_SinBetaSquared * L2 / 0.2e1;
-  Iu3 = C_vev0 * C_vev0 * TanBeta * C_CosBetaSquared * IL5 * 0.5;
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_CosBetaSquared *
+           (L4 + RL5 + L3) / 0.2e1 -
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBetaSquared * L2 / 0.2e1;
+  Iu3 = SMConstants.C_vev0 * SMConstants.C_vev0 * TanBeta * C_CosBetaSquared *
+        IL5 * 0.5;
 
   double cb = 0;
 
   if (Type == 1 or Type == 3) // Type I 2HDM or Lepton Specific
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_SinBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_SinBeta);
   }
   if (Type == 2 or Type == 4) // Type II 2HDM or Flipped
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_CosBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_CosBeta);
   }
   CTempC1 = 1.0 / 48 *
-            (12 * L1 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs));
-  double ct = std::sqrt(2) * C_MassTop / (C_vev0 * C_SinBeta);
-  CTempC2   = 1.0 / 48 *
-            (12 * L2 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs) +
+            (12 * L1 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs));
+  double ct =
+      std::sqrt(2) * SMConstants.C_MassTop / (SMConstants.C_vev0 * C_SinBeta);
+  CTempC2 = 1.0 / 48 *
+            (12 * L2 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs) +
              12 * ct * ct);
 
   if (Type == 1 or Type == 3)
@@ -271,14 +281,14 @@ void Class_Potential_C2HDM::set_gen(const std::vector<double> &p)
   if (IncludeChargeBreakingVEV)
   {
     vevTreeMin[0] = 0;
-    vevTreeMin[1] = C_vev0 * C_CosBeta;
-    vevTreeMin[2] = C_vev0 * C_SinBeta;
+    vevTreeMin[1] = SMConstants.C_vev0 * C_CosBeta;
+    vevTreeMin[2] = SMConstants.C_vev0 * C_SinBeta;
     vevTreeMin[3] = 0;
   }
   else
   {
-    vevTreeMin[0] = C_vev0 * C_CosBeta;
-    vevTreeMin[1] = C_vev0 * C_SinBeta;
+    vevTreeMin[0] = SMConstants.C_vev0 * C_CosBeta;
+    vevTreeMin[1] = SMConstants.C_vev0 * C_SinBeta;
     vevTreeMin[2] = 0;
   }
   vevTree.resize(NHiggs);
@@ -2083,8 +2093,8 @@ void Class_Potential_C2HDM::write() const
 
   ss << "The parameters are :  \n";
   ss << "Model = " << Model << "\n";
-  ss << "v1 = " << C_vev0 * C_CosBeta << "\n";
-  ss << "v2 = " << C_vev0 * C_SinBeta << "\n";
+  ss << "v1 = " << SMConstants.C_vev0 * C_CosBeta << "\n";
+  ss << "v2 = " << SMConstants.C_vev0 * C_SinBeta << "\n";
   ss << "Type = " << Type << "\n";
 
   ss << "beta = " << beta << std::endl;
@@ -2293,8 +2303,8 @@ std::vector<double> Class_Potential_C2HDM::calc_CT() const
   WeinbergNabla = WeinbergFirstDerivative();
   WeinbergHesse = WeinbergSecondDerivative();
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
 
   VectorXd NablaWeinberg(8);
   MatrixXd HesseWeinberg(8, 8), HiggsRot(8, 8);
@@ -2577,8 +2587,8 @@ void Class_Potential_C2HDM::SetCurvatureArrays()
     }
   }
 
-  HiggsVev[4] = C_vev0 * C_CosBeta;
-  HiggsVev[6] = C_vev0 * C_SinBeta;
+  HiggsVev[4] = SMConstants.C_vev0 * C_CosBeta;
+  HiggsVev[6] = SMConstants.C_vev0 * C_SinBeta;
 
   Curvature_Higgs_L2[0][0] = u1;
   Curvature_Higgs_L2[0][1] = 0;
@@ -2779,103 +2789,127 @@ void Class_Potential_C2HDM::SetCurvatureArrays()
     }
   }
 
-  Curvature_Gauge_G2H2[0][0][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[0][3][0][4] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][1][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][2][6] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][3][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][4][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][5][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][6][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][7][3] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][0][4] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][1][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][2][6] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][3][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][4][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][5][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][6][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][7][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
 
-  Curvature_Gauge_G2H2[1][1][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[1][3][0][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][1][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][2][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][3][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][4][1] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][5][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][6][3] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][7][2] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][0][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][1][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][2][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][3][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][4][1] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][5][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][6][3] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][7][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
 
-  Curvature_Gauge_G2H2[2][2][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[2][3][0][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][1][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][2][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][3][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][4][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][5][5] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][6][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][7][7] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][0][4] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][1][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][2][6] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][3][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][4][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][5][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][6][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][7][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][0][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][1][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][2][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][3][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][4][1] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][5][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][6][3] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][7][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][0][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][1][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][2][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][3][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][4][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][5][5] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][6][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][7][7] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][0][4] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][1][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][2][6] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][3][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][4][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][5][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][6][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][7][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][0][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][1][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][2][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][3][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][4][1] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][5][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][6][3] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][7][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
 
-  Curvature_Gauge_G2H2[3][3][0][0] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][1][1] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][2][2] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][3][3] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][4][4] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][5][5] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][6][6] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][7][7] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][0][0] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][1][1] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][2][2] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][3][3] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][4][4] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][5][5] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][6][6] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][7][7] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
 
   std::complex<double> V11, V12, V13, V21, V22, V23, V31, V32, V33;
-  V11 = C_Vud;
-  V12 = C_Vus;
-  V13 = C_Vub;
-  V21 = C_Vcd;
-  V22 = C_Vcs;
-  V23 = C_Vcb;
-  V31 = C_Vtd;
-  V32 = C_Vts;
-  V33 = C_Vtb;
+  V11 = SMConstants.C_Vud;
+  V12 = SMConstants.C_Vus;
+  V13 = SMConstants.C_Vub;
+  V21 = SMConstants.C_Vcd;
+  V22 = SMConstants.C_Vcs;
+  V23 = SMConstants.C_Vcb;
+  V31 = SMConstants.C_Vtd;
+  V32 = SMConstants.C_Vts;
+  V33 = SMConstants.C_Vtb;
 
   MatrixXcd YIJR2(NQuarks, NQuarks), YIJE2(NQuarks, NQuarks),
       YIJS2(NQuarks, NQuarks), YIJP2(NQuarks, NQuarks), YIJRD(NQuarks, NQuarks),
@@ -2895,8 +2929,8 @@ void Class_Potential_C2HDM::SetCurvatureArrays()
   YIJSL = MatrixXcd::Zero(NLepton, NLepton);
   YIJPL = MatrixXcd::Zero(NLepton, NLepton);
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
   double vL = v2;
   double vD = v2;
   if (Type == 2)
@@ -2909,43 +2943,43 @@ void Class_Potential_C2HDM::SetCurvatureArrays()
   else if (Type == 4)
     vD = v1;
 
-  YIJR2(0, 9)  = -std::conj(V11) * C_MassUp / v2;
-  YIJR2(0, 10) = -std::conj(V12) * C_MassUp / v2;
-  YIJR2(0, 11) = -std::conj(V13) * C_MassUp / v2;
+  YIJR2(0, 9)  = -std::conj(V11) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 10) = -std::conj(V12) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 11) = -std::conj(V13) * SMConstants.C_MassUp / v2;
 
-  YIJR2(1, 9)  = -std::conj(V21) * C_MassCharm / v2;
-  YIJR2(1, 10) = -std::conj(V22) * C_MassCharm / v2;
-  YIJR2(1, 11) = -std::conj(V23) * C_MassCharm / v2;
+  YIJR2(1, 9)  = -std::conj(V21) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 10) = -std::conj(V22) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 11) = -std::conj(V23) * SMConstants.C_MassCharm / v2;
 
-  YIJR2(2, 9)  = -std::conj(V31) * C_MassTop / v2;
-  YIJR2(2, 10) = -std::conj(V32) * C_MassTop / v2;
-  YIJR2(2, 11) = -std::conj(V33) * C_MassTop / v2;
+  YIJR2(2, 9)  = -std::conj(V31) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 10) = -std::conj(V32) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 11) = -std::conj(V33) * SMConstants.C_MassTop / v2;
 
-  YIJS2(0, 6) = C_MassUp / v2;
-  YIJS2(1, 7) = C_MassCharm / v2;
-  YIJS2(2, 8) = C_MassTop / v2;
+  YIJS2(0, 6) = SMConstants.C_MassUp / v2;
+  YIJS2(1, 7) = SMConstants.C_MassCharm / v2;
+  YIJS2(2, 8) = SMConstants.C_MassTop / v2;
 
-  YIJSD(3, 9)  = C_MassDown / vD;
-  YIJSD(4, 10) = C_MassStrange / vD;
-  YIJSD(5, 11) = C_MassBottom / vD;
+  YIJSD(3, 9)  = SMConstants.C_MassDown / vD;
+  YIJSD(4, 10) = SMConstants.C_MassStrange / vD;
+  YIJSD(5, 11) = SMConstants.C_MassBottom / vD;
 
-  YIJRD(3, 6) = V11 * C_MassDown / vD;
-  YIJRD(3, 7) = V21 * C_MassDown / vD;
-  YIJRD(3, 8) = V31 * C_MassDown / vD;
-  YIJRD(4, 6) = V12 * C_MassStrange / vD;
-  YIJRD(4, 7) = V22 * C_MassStrange / vD;
-  YIJRD(4, 8) = V32 * C_MassStrange / vD;
-  YIJRD(5, 6) = V13 * C_MassBottom / vD;
-  YIJRD(5, 7) = V23 * C_MassBottom / vD;
-  YIJRD(5, 8) = V33 * C_MassBottom / vD;
+  YIJRD(3, 6) = V11 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 7) = V21 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 8) = V31 * SMConstants.C_MassDown / vD;
+  YIJRD(4, 6) = V12 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 7) = V22 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 8) = V32 * SMConstants.C_MassStrange / vD;
+  YIJRD(5, 6) = V13 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 7) = V23 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 8) = V33 * SMConstants.C_MassBottom / vD;
 
-  YIJRL(1, 6) = C_MassElectron / vL;
-  YIJRL(3, 7) = C_MassMu / vL;
-  YIJRL(5, 8) = C_MassTau / vL;
+  YIJRL(1, 6) = SMConstants.C_MassElectron / vL;
+  YIJRL(3, 7) = SMConstants.C_MassMu / vL;
+  YIJRL(5, 8) = SMConstants.C_MassTau / vL;
 
-  YIJSL(0, 1) = C_MassElectron / vL;
-  YIJSL(2, 3) = C_MassMu / vL;
-  YIJSL(4, 5) = C_MassTau / vL;
+  YIJSL(0, 1) = SMConstants.C_MassElectron / vL;
+  YIJSL(2, 3) = SMConstants.C_MassMu / vL;
+  YIJSL(4, 5) = SMConstants.C_MassTau / vL;
 
   for (std::size_t i = 0; i < NQuarks; i++)
   {
@@ -3043,17 +3077,24 @@ bool Class_Potential_C2HDM::CalculateDebyeSimplified()
 
   if (Type == 1 or Type == 3) // Type I 2HDM oder Lepton Specific
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_SinBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_SinBeta);
   }
   if (Type == 2 or Type == 4) // Type II 2HDM oder Flipped
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_CosBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_CosBeta);
   }
   CTempC1 = 1.0 / 48 *
-            (12 * L1 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs));
-  double ct = std::sqrt(2) * C_MassTop / (C_vev0 * C_SinBeta);
-  CTempC2   = 1.0 / 48 *
-            (12 * L2 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs) +
+            (12 * L1 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs));
+  double ct =
+      std::sqrt(2) * SMConstants.C_MassTop / (SMConstants.C_vev0 * C_SinBeta);
+  CTempC2 = 1.0 / 48 *
+            (12 * L2 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs) +
              12 * ct * ct);
 
   if (Type == 1 or Type == 3)
@@ -3079,10 +3120,10 @@ bool Class_Potential_C2HDM::CalculateDebyeSimplified()
 
 bool Class_Potential_C2HDM::CalculateDebyeGaugeSimplified()
 {
-  DebyeGauge[0][0] = 2 * C_g * C_g;
-  DebyeGauge[1][1] = 2 * C_g * C_g;
-  DebyeGauge[2][2] = 2 * C_g * C_g;
-  DebyeGauge[3][3] = 2 * C_gs * C_gs;
+  DebyeGauge[0][0] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[1][1] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[2][2] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[3][3] = 2 * SMConstants.C_gs * SMConstants.C_gs;
 
   return true;
 }

--- a/src/models/ClassPotentialC2HDM.cpp
+++ b/src/models/ClassPotentialC2HDM.cpp
@@ -14,7 +14,8 @@ namespace BSMPT
 {
 namespace Models
 {
-Class_Potential_C2HDM::Class_Potential_C2HDM()
+Class_Potential_C2HDM::Class_Potential_C2HDM(const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   // TODO Auto-generated constructor stub
   Model         = ModelID::ModelIDs::C2HDM;

--- a/src/models/ClassPotentialCPintheDark.cpp
+++ b/src/models/ClassPotentialCPintheDark.cpp
@@ -28,7 +28,9 @@ namespace BSMPT
 namespace Models
 {
 
-Class_Potential_CPintheDark::Class_Potential_CPintheDark()
+Class_Potential_CPintheDark::Class_Potential_CPintheDark(
+    const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   Model         = ModelID::ModelIDs::CPINTHEDARK;
   NNeutralHiggs = 5; // number of neutral Higgs bosons at T = 0

--- a/src/models/ClassPotentialCPintheDark.cpp
+++ b/src/models/ClassPotentialCPintheDark.cpp
@@ -10,8 +10,8 @@
 #include "Eigen/Dense"
 #include "Eigen/Eigenvalues"
 #include "Eigen/IterativeLinearSolvers"
-#include <BSMPT/models/SMparam.h> // for C_vev0, C_MassTop, C_g
-#include <algorithm>              // for max, copy
+#include <BSMPT/models/SMparam.h> // for SMConstants.C_vev0, SMConstants.C_MassTop, SMConstants.C_g
+#include <algorithm> // for max, copy
 #include <iomanip>
 #include <iostream> // for operator<<, endl, basic_o...
 #include <memory>   // for allocator_traits<>::value...
@@ -257,9 +257,9 @@ void Class_Potential_CPintheDark::set_gen(const std::vector<double> &par)
   L8   = par[12];
 
   // set vev
-  v1 = C_vev0;
+  v1 = SMConstants.C_vev0;
 
-  scale = C_vev0; // renormalisation scale is set to the SM VEV
+  scale = SMConstants.C_vev0; // renormalisation scale is set to the SM VEV
 
   vevTreeMin.resize(nVEV);
   vevTree.resize(NHiggs);
@@ -1989,219 +1989,279 @@ void Class_Potential_CPintheDark::SetCurvatureArrays()
   Curvature_Higgs_L4[8][8][7][7] = L8;
   Curvature_Higgs_L4[8][8][8][8] = 0.6e1 * L6;
 
-  Curvature_Gauge_G2H2[0][0][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][7][7] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][0][4] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][1][5] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][2][6] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][3][7] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][4][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][5][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][6][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][7][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][7][7] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][0][5] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][1][4] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][2][7] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][3][6] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][4][1] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][5][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][6][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][7][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][7][7] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][0][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][1][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][2][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][3][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][4][4] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][5][5] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][6][6] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][7][7] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][0][4] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][1][5] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][2][6] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][3][7] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][4][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][5][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][6][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][7][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][0][5] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][1][4] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][2][7] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][3][6] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][4][1] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][5][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][6][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][7][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][0][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][1][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][2][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][3][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][4][4] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][5][5] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][6][6] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][7][7] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][0][0] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][1][1] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][2][2] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][3][3] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][4][4] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][5][5] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][6][6] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][7][7] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][0][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][1][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][2][6] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][3][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][4][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][5][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][6][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][7][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][0][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][1][4] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][2][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][3][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][4][1] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][5][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][6][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][7][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][0][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][1][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][2][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][3][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][4][4] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][5][5] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][6][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][7][7] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][0][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][1][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][2][6] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][3][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][4][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][5][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][6][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][7][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][0][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][1][4] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][2][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][3][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][4][1] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][5][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][6][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][7][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][0][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][1][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][2][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][3][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][4][4] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][5][5] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][6][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][7][7] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][0][0] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][1][1] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][2][2] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][3][3] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][4][4] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][5][5] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][6][6] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][7][7] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
 
   std::complex<double> V11, V12, V13, V21, V22, V23, V31, V32, V33;
-  V11 = C_Vud;
-  V12 = C_Vus;
-  V13 = C_Vub;
-  V21 = C_Vcd;
-  V22 = C_Vcs;
-  V23 = C_Vcb;
-  V31 = C_Vtd;
-  V32 = C_Vts;
-  V33 = C_Vtb;
+  V11 = SMConstants.C_Vud;
+  V12 = SMConstants.C_Vus;
+  V13 = SMConstants.C_Vub;
+  V21 = SMConstants.C_Vcd;
+  V22 = SMConstants.C_Vcs;
+  V23 = SMConstants.C_Vcb;
+  V31 = SMConstants.C_Vtd;
+  V32 = SMConstants.C_Vts;
+  V33 = SMConstants.C_Vtb;
 
-  Curvature_Quark_F2H1[0][1][4]   = 0.1e1 / v1 * C_MassUp;
-  Curvature_Quark_F2H1[0][1][5]   = -II / v1 * C_MassUp;
-  Curvature_Quark_F2H1[0][3][0]   = 0.1e1 / v1 * C_MassDown * V11;
-  Curvature_Quark_F2H1[0][3][1]   = II / v1 * C_MassDown * V11;
-  Curvature_Quark_F2H1[0][7][0]   = V12 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[0][7][1]   = II * V12 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[0][11][0]  = V13 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[0][11][1]  = II * V13 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[1][0][4]   = 0.1e1 / v1 * C_MassUp;
-  Curvature_Quark_F2H1[1][0][5]   = -II / v1 * C_MassUp;
-  Curvature_Quark_F2H1[1][2][0]   = -0.1e1 / v1 * C_MassUp * std::conj(V11);
-  Curvature_Quark_F2H1[1][2][1]   = II / v1 * C_MassUp * std::conj(V11);
-  Curvature_Quark_F2H1[1][6][0]   = -0.1e1 / v1 * C_MassUp * std::conj(V12);
-  Curvature_Quark_F2H1[1][6][1]   = II / v1 * C_MassUp * std::conj(V12);
-  Curvature_Quark_F2H1[1][10][0]  = -0.1e1 / v1 * C_MassUp * std::conj(V13);
-  Curvature_Quark_F2H1[1][10][1]  = II / v1 * C_MassUp * std::conj(V13);
-  Curvature_Quark_F2H1[2][1][0]   = -0.1e1 / v1 * C_MassUp * std::conj(V11);
-  Curvature_Quark_F2H1[2][1][1]   = II / v1 * C_MassUp * std::conj(V11);
-  Curvature_Quark_F2H1[2][3][4]   = 0.1e1 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[2][3][5]   = II / v1 * C_MassDown;
-  Curvature_Quark_F2H1[2][5][0]   = -0.1e1 / v1 * C_MassCharm * std::conj(V21);
-  Curvature_Quark_F2H1[2][5][1]   = II / v1 * C_MassCharm * std::conj(V21);
-  Curvature_Quark_F2H1[2][9][0]   = -0.1e1 / v1 * C_MassTop * std::conj(V31);
-  Curvature_Quark_F2H1[2][9][1]   = II / v1 * C_MassTop * std::conj(V31);
-  Curvature_Quark_F2H1[3][0][0]   = 0.1e1 / v1 * C_MassDown * V11;
-  Curvature_Quark_F2H1[3][0][1]   = II / v1 * C_MassDown * V11;
-  Curvature_Quark_F2H1[3][2][4]   = 0.1e1 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[3][2][5]   = II / v1 * C_MassDown;
-  Curvature_Quark_F2H1[3][4][0]   = V21 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[3][4][1]   = II * V21 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[3][8][0]   = 0.1e1 / v1 * C_MassDown * V31;
-  Curvature_Quark_F2H1[3][8][1]   = II / v1 * C_MassDown * V31;
-  Curvature_Quark_F2H1[4][3][0]   = V21 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[4][3][1]   = II * V21 / v1 * C_MassDown;
-  Curvature_Quark_F2H1[4][5][4]   = 0.1e1 / v1 * C_MassCharm;
-  Curvature_Quark_F2H1[4][5][5]   = -II / v1 * C_MassCharm;
-  Curvature_Quark_F2H1[4][7][0]   = V22 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[4][7][1]   = II * V22 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[4][11][0]  = V23 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[4][11][1]  = II * V23 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[5][2][0]   = -0.1e1 / v1 * C_MassCharm * std::conj(V21);
-  Curvature_Quark_F2H1[5][2][1]   = II / v1 * C_MassCharm * std::conj(V21);
-  Curvature_Quark_F2H1[5][4][4]   = 0.1e1 / v1 * C_MassCharm;
-  Curvature_Quark_F2H1[5][4][5]   = -II / v1 * C_MassCharm;
-  Curvature_Quark_F2H1[5][6][0]   = -0.1e1 / v1 * C_MassCharm * std::conj(V22);
-  Curvature_Quark_F2H1[5][6][1]   = II / v1 * C_MassCharm * std::conj(V22);
-  Curvature_Quark_F2H1[5][10][0]  = -0.1e1 / v1 * C_MassCharm * std::conj(V23);
-  Curvature_Quark_F2H1[5][10][1]  = II / v1 * C_MassCharm * std::conj(V23);
-  Curvature_Quark_F2H1[6][1][0]   = -0.1e1 / v1 * C_MassUp * std::conj(V12);
-  Curvature_Quark_F2H1[6][1][1]   = II / v1 * C_MassUp * std::conj(V12);
-  Curvature_Quark_F2H1[6][5][0]   = -0.1e1 / v1 * C_MassCharm * std::conj(V22);
-  Curvature_Quark_F2H1[6][5][1]   = II / v1 * C_MassCharm * std::conj(V22);
-  Curvature_Quark_F2H1[6][7][4]   = 0.1e1 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[6][7][5]   = II / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[6][9][0]   = -0.1e1 / v1 * C_MassTop * std::conj(V32);
-  Curvature_Quark_F2H1[6][9][1]   = II / v1 * C_MassTop * std::conj(V32);
-  Curvature_Quark_F2H1[7][0][0]   = V12 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][0][1]   = II * V12 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][4][0]   = V22 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][4][1]   = II * V22 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][6][4]   = 0.1e1 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][6][5]   = II / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][8][0]   = V32 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[7][8][1]   = II * V32 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[8][3][0]   = 0.1e1 / v1 * C_MassDown * V31;
-  Curvature_Quark_F2H1[8][3][1]   = II / v1 * C_MassDown * V31;
-  Curvature_Quark_F2H1[8][7][0]   = V32 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[8][7][1]   = II * V32 / v1 * C_MassStrange;
-  Curvature_Quark_F2H1[8][9][4]   = 0.1e1 / v1 * C_MassTop;
-  Curvature_Quark_F2H1[8][9][5]   = -II / v1 * C_MassTop;
-  Curvature_Quark_F2H1[8][11][0]  = V33 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[8][11][1]  = II * V33 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[9][2][0]   = -0.1e1 / v1 * C_MassTop * std::conj(V31);
-  Curvature_Quark_F2H1[9][2][1]   = II / v1 * C_MassTop * std::conj(V31);
-  Curvature_Quark_F2H1[9][6][0]   = -0.1e1 / v1 * C_MassTop * std::conj(V32);
-  Curvature_Quark_F2H1[9][6][1]   = II / v1 * C_MassTop * std::conj(V32);
-  Curvature_Quark_F2H1[9][8][4]   = 0.1e1 / v1 * C_MassTop;
-  Curvature_Quark_F2H1[9][8][5]   = -II / v1 * C_MassTop;
-  Curvature_Quark_F2H1[9][10][0]  = -0.1e1 / v1 * C_MassTop * std::conj(V33);
-  Curvature_Quark_F2H1[9][10][1]  = II / v1 * C_MassTop * std::conj(V33);
-  Curvature_Quark_F2H1[10][1][0]  = -0.1e1 / v1 * C_MassUp * std::conj(V13);
-  Curvature_Quark_F2H1[10][1][1]  = II / v1 * C_MassUp * std::conj(V13);
-  Curvature_Quark_F2H1[10][5][0]  = -0.1e1 / v1 * C_MassCharm * std::conj(V23);
-  Curvature_Quark_F2H1[10][5][1]  = II / v1 * C_MassCharm * std::conj(V23);
-  Curvature_Quark_F2H1[10][9][0]  = -0.1e1 / v1 * C_MassTop * std::conj(V33);
-  Curvature_Quark_F2H1[10][9][1]  = II / v1 * C_MassTop * std::conj(V33);
-  Curvature_Quark_F2H1[10][11][4] = 0.1e1 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[10][11][5] = II / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][0][0]  = V13 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][0][1]  = II * V13 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][4][0]  = V23 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][4][1]  = II * V23 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][8][0]  = V33 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][8][1]  = II * V33 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][10][4] = 0.1e1 / v1 * C_MassBottom;
-  Curvature_Quark_F2H1[11][10][5] = II / v1 * C_MassBottom;
+  Curvature_Quark_F2H1[0][1][4]  = 0.1e1 / v1 * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[0][1][5]  = -II / v1 * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[0][3][0]  = 0.1e1 / v1 * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[0][3][1]  = II / v1 * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[0][7][0]  = V12 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[0][7][1]  = II * V12 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[0][11][0] = V13 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[0][11][1] = II * V13 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[1][0][4]  = 0.1e1 / v1 * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[1][0][5]  = -II / v1 * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[1][2][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V11);
+  Curvature_Quark_F2H1[1][2][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V11);
+  Curvature_Quark_F2H1[1][6][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V12);
+  Curvature_Quark_F2H1[1][6][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V12);
+  Curvature_Quark_F2H1[1][10][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V13);
+  Curvature_Quark_F2H1[1][10][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V13);
+  Curvature_Quark_F2H1[2][1][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V11);
+  Curvature_Quark_F2H1[2][1][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V11);
+  Curvature_Quark_F2H1[2][3][4] = 0.1e1 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[2][3][5] = II / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[2][5][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V21);
+  Curvature_Quark_F2H1[2][5][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V21);
+  Curvature_Quark_F2H1[2][9][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V31);
+  Curvature_Quark_F2H1[2][9][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V31);
+  Curvature_Quark_F2H1[3][0][0]  = 0.1e1 / v1 * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[3][0][1]  = II / v1 * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[3][2][4]  = 0.1e1 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][2][5]  = II / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][4][0]  = V21 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][4][1]  = II * V21 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][8][0]  = 0.1e1 / v1 * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[3][8][1]  = II / v1 * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[4][3][0]  = V21 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[4][3][1]  = II * V21 / v1 * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[4][5][4]  = 0.1e1 / v1 * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[4][5][5]  = -II / v1 * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[4][7][0]  = V22 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[4][7][1]  = II * V22 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[4][11][0] = V23 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[4][11][1] = II * V23 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[5][2][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V21);
+  Curvature_Quark_F2H1[5][2][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V21);
+  Curvature_Quark_F2H1[5][4][4] = 0.1e1 / v1 * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[5][4][5] = -II / v1 * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[5][6][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V22);
+  Curvature_Quark_F2H1[5][6][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V22);
+  Curvature_Quark_F2H1[5][10][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V23);
+  Curvature_Quark_F2H1[5][10][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V23);
+  Curvature_Quark_F2H1[6][1][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V12);
+  Curvature_Quark_F2H1[6][1][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V12);
+  Curvature_Quark_F2H1[6][5][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V22);
+  Curvature_Quark_F2H1[6][5][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V22);
+  Curvature_Quark_F2H1[6][7][4] = 0.1e1 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[6][7][5] = II / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[6][9][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V32);
+  Curvature_Quark_F2H1[6][9][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V32);
+  Curvature_Quark_F2H1[7][0][0]  = V12 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][0][1]  = II * V12 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][4][0]  = V22 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][4][1]  = II * V22 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][6][4]  = 0.1e1 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][6][5]  = II / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][8][0]  = V32 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][8][1]  = II * V32 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[8][3][0]  = 0.1e1 / v1 * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[8][3][1]  = II / v1 * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[8][7][0]  = V32 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[8][7][1]  = II * V32 / v1 * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[8][9][4]  = 0.1e1 / v1 * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[8][9][5]  = -II / v1 * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[8][11][0] = V33 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[8][11][1] = II * V33 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[9][2][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V31);
+  Curvature_Quark_F2H1[9][2][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V31);
+  Curvature_Quark_F2H1[9][6][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V32);
+  Curvature_Quark_F2H1[9][6][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V32);
+  Curvature_Quark_F2H1[9][8][4] = 0.1e1 / v1 * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[9][8][5] = -II / v1 * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[9][10][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V33);
+  Curvature_Quark_F2H1[9][10][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V33);
+  Curvature_Quark_F2H1[10][1][0] =
+      -0.1e1 / v1 * SMConstants.C_MassUp * std::conj(V13);
+  Curvature_Quark_F2H1[10][1][1] =
+      II / v1 * SMConstants.C_MassUp * std::conj(V13);
+  Curvature_Quark_F2H1[10][5][0] =
+      -0.1e1 / v1 * SMConstants.C_MassCharm * std::conj(V23);
+  Curvature_Quark_F2H1[10][5][1] =
+      II / v1 * SMConstants.C_MassCharm * std::conj(V23);
+  Curvature_Quark_F2H1[10][9][0] =
+      -0.1e1 / v1 * SMConstants.C_MassTop * std::conj(V33);
+  Curvature_Quark_F2H1[10][9][1] =
+      II / v1 * SMConstants.C_MassTop * std::conj(V33);
+  Curvature_Quark_F2H1[10][11][4] = 0.1e1 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[10][11][5] = II / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][0][0]  = V13 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][0][1]  = II * V13 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][4][0]  = V23 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][4][1]  = II * V23 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][8][0]  = V33 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][8][1]  = II * V33 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][10][4] = 0.1e1 / v1 * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][10][5] = II / v1 * SMConstants.C_MassBottom;
 
-  Curvature_Lepton_F2H1[0][1][4] = 0.1e1 / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[0][1][5] = II / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[1][0][4] = 0.1e1 / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[1][0][5] = II / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[1][6][0] = 0.1e1 / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[1][6][1] = II / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[2][3][4] = 0.1e1 / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[2][3][5] = II / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[3][2][4] = 0.1e1 / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[3][2][5] = II / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[3][7][0] = 0.1e1 / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[3][7][1] = II / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[4][5][4] = 0.1e1 / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[4][5][5] = II / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[5][4][4] = 0.1e1 / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[5][4][5] = II / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[5][8][0] = 0.1e1 / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[5][8][1] = II / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[6][1][0] = 0.1e1 / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[6][1][1] = II / v1 * C_MassElectron;
-  Curvature_Lepton_F2H1[7][3][0] = 0.1e1 / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[7][3][1] = II / v1 * C_MassMu;
-  Curvature_Lepton_F2H1[8][5][0] = 0.1e1 / v1 * C_MassTau;
-  Curvature_Lepton_F2H1[8][5][1] = II / v1 * C_MassTau;
+  Curvature_Lepton_F2H1[0][1][4] = 0.1e1 / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[0][1][5] = II / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][0][4] = 0.1e1 / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][0][5] = II / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][6][0] = 0.1e1 / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][6][1] = II / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[2][3][4] = 0.1e1 / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[2][3][5] = II / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][2][4] = 0.1e1 / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][2][5] = II / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][7][0] = 0.1e1 / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][7][1] = II / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[4][5][4] = 0.1e1 / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[4][5][5] = II / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][4][4] = 0.1e1 / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][4][5] = II / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][8][0] = 0.1e1 / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][8][1] = II / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[6][1][0] = 0.1e1 / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[6][1][1] = II / v1 * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[7][3][0] = 0.1e1 / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[7][3][1] = II / v1 * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[8][5][0] = 0.1e1 / v1 * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[8][5][1] = II / v1 * SMConstants.C_MassTau;
 }
 
 bool Class_Potential_CPintheDark::CalculateDebyeSimplified()

--- a/src/models/ClassPotentialCxSM.cpp
+++ b/src/models/ClassPotentialCxSM.cpp
@@ -1023,46 +1023,58 @@ void Class_CxSM::SetCurvatureArrays()
   Curvature_Higgs_L4[5][5][4][4] = d2 / 0.2e1;
   Curvature_Higgs_L4[5][5][5][5] = 0.3e1 / 0.2e1 * d2;
 
-  Curvature_Gauge_G2H2[0][0][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][0][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][1][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][2][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][3][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][0][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][1][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][2][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][3][1] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][0][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][1][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][2][2] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][3][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][0][3] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][1][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][2][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][3][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][0][2] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][1][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][2][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][3][1] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][0][0] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][1][1] = C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][2][2] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][3][3] = -C_gs * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][0][0] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][1][1] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][2][2] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][3][3] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][0][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][1][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][2][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][3][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][0][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][1][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][2][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][3][1] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][0][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][1][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][2][2] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][3][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][0][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][1][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][2][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][3][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][0][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][1][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][2][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][3][1] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][0][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][1][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][2][2] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][3][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][0][0] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][1][1] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][2][2] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][3][3] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
 
   MatrixXcd YIJQc1(NQuarks, NQuarks), YIJQc2(NQuarks, NQuarks),
       YIJQc2OI(NQuarks, NQuarks), YIJQg0(NQuarks, NQuarks),
@@ -1070,148 +1082,170 @@ void Class_CxSM::SetCurvatureArrays()
       YIJQh2(NQuarks, NQuarks), YIJQh3(NQuarks, NQuarks);
 
   std::complex<double> V11, V12, V13, V21, V22, V23, V31, V32, V33;
-  V11 = C_Vud;
-  V12 = C_Vus;
-  V13 = C_Vub;
-  V21 = C_Vcd;
-  V22 = C_Vcs;
-  V23 = C_Vcb;
-  V31 = C_Vtd;
-  V32 = C_Vts;
-  V33 = C_Vtb;
+  V11 = SMConstants.C_Vud;
+  V12 = SMConstants.C_Vus;
+  V13 = SMConstants.C_Vub;
+  V21 = SMConstants.C_Vcd;
+  V22 = SMConstants.C_Vcs;
+  V23 = SMConstants.C_Vcb;
+  V31 = SMConstants.C_Vtd;
+  V32 = SMConstants.C_Vts;
+  V33 = SMConstants.C_Vtb;
 
   std::complex<double> VC11, VC12, VC13, VC21, VC22, VC23, VC31, VC32, VC33;
-  VC11 = std::conj(C_Vud);
-  VC12 = std::conj(C_Vus);
-  VC13 = std::conj(C_Vub);
-  VC21 = std::conj(C_Vcd);
-  VC22 = std::conj(C_Vcs);
-  VC23 = std::conj(C_Vcb);
-  VC31 = std::conj(C_Vtd);
-  VC32 = std::conj(C_Vts);
-  VC33 = std::conj(C_Vtb);
+  VC11 = std::conj(SMConstants.C_Vud);
+  VC12 = std::conj(SMConstants.C_Vus);
+  VC13 = std::conj(SMConstants.C_Vub);
+  VC21 = std::conj(SMConstants.C_Vcd);
+  VC22 = std::conj(SMConstants.C_Vcs);
+  VC23 = std::conj(SMConstants.C_Vcb);
+  VC31 = std::conj(SMConstants.C_Vtd);
+  VC32 = std::conj(SMConstants.C_Vts);
+  VC33 = std::conj(SMConstants.C_Vtb);
 
-  Curvature_Lepton_F2H1[0][1][2] = II / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[0][1][3] = 0.1e1 / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[1][0][2] = II / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[1][0][3] = 0.1e1 / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[1][6][0] = 0.1e1 / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[1][6][1] = II / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[2][3][2] = II / vh * C_MassMu;
-  Curvature_Lepton_F2H1[2][3][3] = 0.1e1 / vh * C_MassMu;
-  Curvature_Lepton_F2H1[3][2][2] = II / vh * C_MassMu;
-  Curvature_Lepton_F2H1[3][2][3] = 0.1e1 / vh * C_MassMu;
-  Curvature_Lepton_F2H1[3][7][0] = 0.1e1 / vh * C_MassMu;
-  Curvature_Lepton_F2H1[3][7][1] = II / vh * C_MassMu;
-  Curvature_Lepton_F2H1[4][5][2] = II / vh * C_MassTau;
-  Curvature_Lepton_F2H1[4][5][3] = 0.1e1 / vh * C_MassTau;
-  Curvature_Lepton_F2H1[5][4][2] = II / vh * C_MassTau;
-  Curvature_Lepton_F2H1[5][4][3] = 0.1e1 / vh * C_MassTau;
-  Curvature_Lepton_F2H1[5][8][0] = 0.1e1 / vh * C_MassTau;
-  Curvature_Lepton_F2H1[5][8][1] = II / vh * C_MassTau;
-  Curvature_Lepton_F2H1[6][1][0] = 0.1e1 / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[6][1][1] = II / vh * C_MassElectron;
-  Curvature_Lepton_F2H1[7][3][0] = 0.1e1 / vh * C_MassMu;
-  Curvature_Lepton_F2H1[7][3][1] = II / vh * C_MassMu;
-  Curvature_Lepton_F2H1[8][5][0] = 0.1e1 / vh * C_MassTau;
-  Curvature_Lepton_F2H1[8][5][1] = II / vh * C_MassTau;
+  Curvature_Lepton_F2H1[0][1][2] = II / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[0][1][3] = 0.1e1 / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][0][2] = II / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][0][3] = 0.1e1 / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][6][0] = 0.1e1 / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[1][6][1] = II / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[2][3][2] = II / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[2][3][3] = 0.1e1 / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][2][2] = II / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][2][3] = 0.1e1 / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][7][0] = 0.1e1 / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[3][7][1] = II / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[4][5][2] = II / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[4][5][3] = 0.1e1 / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][4][2] = II / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][4][3] = 0.1e1 / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][8][0] = 0.1e1 / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[5][8][1] = II / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[6][1][0] = 0.1e1 / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[6][1][1] = II / vh * SMConstants.C_MassElectron;
+  Curvature_Lepton_F2H1[7][3][0] = 0.1e1 / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[7][3][1] = II / vh * SMConstants.C_MassMu;
+  Curvature_Lepton_F2H1[8][5][0] = 0.1e1 / vh * SMConstants.C_MassTau;
+  Curvature_Lepton_F2H1[8][5][1] = II / vh * SMConstants.C_MassTau;
 
-  Curvature_Quark_F2H1[0][6][2]  = -II / vh * C_MassUp;
-  Curvature_Quark_F2H1[0][6][3]  = 0.1e1 / vh * C_MassUp;
-  Curvature_Quark_F2H1[0][9][0]  = -0.1e1 / vh * C_MassUp * conj(V11);
-  Curvature_Quark_F2H1[0][9][1]  = II / vh * C_MassUp * conj(V11);
-  Curvature_Quark_F2H1[0][10][0] = -0.1e1 / vh * C_MassUp * conj(V12);
-  Curvature_Quark_F2H1[0][10][1] = II / vh * C_MassUp * conj(V12);
-  Curvature_Quark_F2H1[0][11][0] = -0.1e1 / vh * C_MassUp * conj(V13);
-  Curvature_Quark_F2H1[0][11][1] = II / vh * C_MassUp * conj(V13);
-  Curvature_Quark_F2H1[1][7][2]  = -II / vh * C_MassCharm;
-  Curvature_Quark_F2H1[1][7][3]  = 0.1e1 / vh * C_MassCharm;
-  Curvature_Quark_F2H1[1][9][0]  = -0.1e1 / vh * C_MassCharm * conj(V21);
-  Curvature_Quark_F2H1[1][9][1]  = II / vh * C_MassCharm * conj(V21);
-  Curvature_Quark_F2H1[1][10][0] = -0.1e1 / vh * C_MassCharm * conj(V22);
-  Curvature_Quark_F2H1[1][10][1] = II / vh * C_MassCharm * conj(V22);
-  Curvature_Quark_F2H1[1][11][0] = -0.1e1 / vh * C_MassCharm * conj(V23);
-  Curvature_Quark_F2H1[1][11][1] = II / vh * C_MassCharm * conj(V23);
-  Curvature_Quark_F2H1[2][8][2]  = -II / vh * C_MassTop;
-  Curvature_Quark_F2H1[2][8][3]  = 0.1e1 / vh * C_MassTop;
-  Curvature_Quark_F2H1[2][9][0]  = -0.1e1 / vh * C_MassTop * conj(V31);
-  Curvature_Quark_F2H1[2][9][1]  = II / vh * C_MassTop * conj(V31);
-  Curvature_Quark_F2H1[2][10][0] = -0.1e1 / vh * C_MassTop * conj(V32);
-  Curvature_Quark_F2H1[2][10][1] = II / vh * C_MassTop * conj(V32);
-  Curvature_Quark_F2H1[2][11][0] = -0.1e1 / vh * C_MassTop * conj(V33);
-  Curvature_Quark_F2H1[2][11][1] = II / vh * C_MassTop * conj(V33);
-  Curvature_Quark_F2H1[3][6][0]  = 0.1e1 / vh * C_MassDown * V11;
-  Curvature_Quark_F2H1[3][6][1]  = II / vh * C_MassDown * V11;
-  Curvature_Quark_F2H1[3][7][0]  = V21 / vh * C_MassDown;
-  Curvature_Quark_F2H1[3][7][1]  = II * V21 / vh * C_MassDown;
-  Curvature_Quark_F2H1[3][8][0]  = 0.1e1 / vh * C_MassDown * V31;
-  Curvature_Quark_F2H1[3][8][1]  = II / vh * C_MassDown * V31;
-  Curvature_Quark_F2H1[3][9][2]  = II / vh * C_MassDown;
-  Curvature_Quark_F2H1[3][9][3]  = 0.1e1 / vh * C_MassDown;
-  Curvature_Quark_F2H1[4][6][0]  = 0.1e1 / vh * C_MassStrange * V12;
-  Curvature_Quark_F2H1[4][6][1]  = II / vh * C_MassStrange * V12;
-  Curvature_Quark_F2H1[4][7][0]  = V22 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[4][7][1]  = II * V22 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[4][8][0]  = 0.1e1 / vh * C_MassStrange * V32;
-  Curvature_Quark_F2H1[4][8][1]  = II / vh * C_MassStrange * V32;
-  Curvature_Quark_F2H1[4][10][2] = II / vh * C_MassStrange;
-  Curvature_Quark_F2H1[4][10][3] = 0.1e1 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[5][6][0]  = V13 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[5][6][1]  = II / vh * C_MassBottom * V13;
-  Curvature_Quark_F2H1[5][7][0]  = V23 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[5][7][1]  = II / vh * C_MassBottom * V23;
-  Curvature_Quark_F2H1[5][8][0]  = V33 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[5][8][1]  = II / vh * C_MassBottom * V33;
-  Curvature_Quark_F2H1[5][11][2] = II / vh * C_MassBottom;
-  Curvature_Quark_F2H1[5][11][3] = 0.1e1 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[6][0][2]  = -II / vh * C_MassUp;
-  Curvature_Quark_F2H1[6][0][3]  = 0.1e1 / vh * C_MassUp;
-  Curvature_Quark_F2H1[6][3][0]  = 0.1e1 / vh * C_MassDown * V11;
-  Curvature_Quark_F2H1[6][3][1]  = II / vh * C_MassDown * V11;
-  Curvature_Quark_F2H1[6][4][0]  = 0.1e1 / vh * C_MassStrange * V12;
-  Curvature_Quark_F2H1[6][4][1]  = II / vh * C_MassStrange * V12;
-  Curvature_Quark_F2H1[6][5][0]  = V13 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[6][5][1]  = II / vh * C_MassBottom * V13;
-  Curvature_Quark_F2H1[7][1][2]  = -II / vh * C_MassCharm;
-  Curvature_Quark_F2H1[7][1][3]  = 0.1e1 / vh * C_MassCharm;
-  Curvature_Quark_F2H1[7][3][0]  = V21 / vh * C_MassDown;
-  Curvature_Quark_F2H1[7][3][1]  = II * V21 / vh * C_MassDown;
-  Curvature_Quark_F2H1[7][4][0]  = V22 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[7][4][1]  = II * V22 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[7][5][0]  = V23 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[7][5][1]  = II / vh * C_MassBottom * V23;
-  Curvature_Quark_F2H1[8][2][2]  = -II / vh * C_MassTop;
-  Curvature_Quark_F2H1[8][2][3]  = 0.1e1 / vh * C_MassTop;
-  Curvature_Quark_F2H1[8][3][0]  = 0.1e1 / vh * C_MassDown * V31;
-  Curvature_Quark_F2H1[8][3][1]  = II / vh * C_MassDown * V31;
-  Curvature_Quark_F2H1[8][4][0]  = 0.1e1 / vh * C_MassStrange * V32;
-  Curvature_Quark_F2H1[8][4][1]  = II / vh * C_MassStrange * V32;
-  Curvature_Quark_F2H1[8][5][0]  = V33 / vh * C_MassBottom;
-  Curvature_Quark_F2H1[8][5][1]  = II / vh * C_MassBottom * V33;
-  Curvature_Quark_F2H1[9][0][0]  = -0.1e1 / vh * C_MassUp * conj(V11);
-  Curvature_Quark_F2H1[9][0][1]  = II / vh * C_MassUp * conj(V11);
-  Curvature_Quark_F2H1[9][1][0]  = -0.1e1 / vh * C_MassCharm * conj(V21);
-  Curvature_Quark_F2H1[9][1][1]  = II / vh * C_MassCharm * conj(V21);
-  Curvature_Quark_F2H1[9][2][0]  = -0.1e1 / vh * C_MassTop * conj(V31);
-  Curvature_Quark_F2H1[9][2][1]  = II / vh * C_MassTop * conj(V31);
-  Curvature_Quark_F2H1[9][3][2]  = II / vh * C_MassDown;
-  Curvature_Quark_F2H1[9][3][3]  = 0.1e1 / vh * C_MassDown;
-  Curvature_Quark_F2H1[10][0][0] = -0.1e1 / vh * C_MassUp * conj(V12);
-  Curvature_Quark_F2H1[10][0][1] = II / vh * C_MassUp * conj(V12);
-  Curvature_Quark_F2H1[10][1][0] = -0.1e1 / vh * C_MassCharm * conj(V22);
-  Curvature_Quark_F2H1[10][1][1] = II / vh * C_MassCharm * conj(V22);
-  Curvature_Quark_F2H1[10][2][0] = -0.1e1 / vh * C_MassTop * conj(V32);
-  Curvature_Quark_F2H1[10][2][1] = II / vh * C_MassTop * conj(V32);
-  Curvature_Quark_F2H1[10][4][2] = II / vh * C_MassStrange;
-  Curvature_Quark_F2H1[10][4][3] = 0.1e1 / vh * C_MassStrange;
-  Curvature_Quark_F2H1[11][0][0] = -0.1e1 / vh * C_MassUp * conj(V13);
-  Curvature_Quark_F2H1[11][0][1] = II / vh * C_MassUp * conj(V13);
-  Curvature_Quark_F2H1[11][1][0] = -0.1e1 / vh * C_MassCharm * conj(V23);
-  Curvature_Quark_F2H1[11][1][1] = II / vh * C_MassCharm * conj(V23);
-  Curvature_Quark_F2H1[11][2][0] = -0.1e1 / vh * C_MassTop * conj(V33);
-  Curvature_Quark_F2H1[11][2][1] = II / vh * C_MassTop * conj(V33);
-  Curvature_Quark_F2H1[11][5][2] = II / vh * C_MassBottom;
-  Curvature_Quark_F2H1[11][5][3] = 0.1e1 / vh * C_MassBottom;
+  Curvature_Quark_F2H1[0][6][2] = -II / vh * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[0][6][3] = 0.1e1 / vh * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[0][9][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V11);
+  Curvature_Quark_F2H1[0][9][1] = II / vh * SMConstants.C_MassUp * conj(V11);
+  Curvature_Quark_F2H1[0][10][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V12);
+  Curvature_Quark_F2H1[0][10][1] = II / vh * SMConstants.C_MassUp * conj(V12);
+  Curvature_Quark_F2H1[0][11][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V13);
+  Curvature_Quark_F2H1[0][11][1] = II / vh * SMConstants.C_MassUp * conj(V13);
+  Curvature_Quark_F2H1[1][7][2]  = -II / vh * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[1][7][3]  = 0.1e1 / vh * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[1][9][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V21);
+  Curvature_Quark_F2H1[1][9][1] = II / vh * SMConstants.C_MassCharm * conj(V21);
+  Curvature_Quark_F2H1[1][10][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V22);
+  Curvature_Quark_F2H1[1][10][1] =
+      II / vh * SMConstants.C_MassCharm * conj(V22);
+  Curvature_Quark_F2H1[1][11][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V23);
+  Curvature_Quark_F2H1[1][11][1] =
+      II / vh * SMConstants.C_MassCharm * conj(V23);
+  Curvature_Quark_F2H1[2][8][2] = -II / vh * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[2][8][3] = 0.1e1 / vh * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[2][9][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V31);
+  Curvature_Quark_F2H1[2][9][1] = II / vh * SMConstants.C_MassTop * conj(V31);
+  Curvature_Quark_F2H1[2][10][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V32);
+  Curvature_Quark_F2H1[2][10][1] = II / vh * SMConstants.C_MassTop * conj(V32);
+  Curvature_Quark_F2H1[2][11][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V33);
+  Curvature_Quark_F2H1[2][11][1] = II / vh * SMConstants.C_MassTop * conj(V33);
+  Curvature_Quark_F2H1[3][6][0]  = 0.1e1 / vh * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[3][6][1]  = II / vh * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[3][7][0]  = V21 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][7][1]  = II * V21 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][8][0]  = 0.1e1 / vh * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[3][8][1]  = II / vh * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[3][9][2]  = II / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[3][9][3]  = 0.1e1 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[4][6][0]  = 0.1e1 / vh * SMConstants.C_MassStrange * V12;
+  Curvature_Quark_F2H1[4][6][1]  = II / vh * SMConstants.C_MassStrange * V12;
+  Curvature_Quark_F2H1[4][7][0]  = V22 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[4][7][1]  = II * V22 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[4][8][0]  = 0.1e1 / vh * SMConstants.C_MassStrange * V32;
+  Curvature_Quark_F2H1[4][8][1]  = II / vh * SMConstants.C_MassStrange * V32;
+  Curvature_Quark_F2H1[4][10][2] = II / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[4][10][3] = 0.1e1 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[5][6][0]  = V13 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[5][6][1]  = II / vh * SMConstants.C_MassBottom * V13;
+  Curvature_Quark_F2H1[5][7][0]  = V23 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[5][7][1]  = II / vh * SMConstants.C_MassBottom * V23;
+  Curvature_Quark_F2H1[5][8][0]  = V33 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[5][8][1]  = II / vh * SMConstants.C_MassBottom * V33;
+  Curvature_Quark_F2H1[5][11][2] = II / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[5][11][3] = 0.1e1 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[6][0][2]  = -II / vh * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[6][0][3]  = 0.1e1 / vh * SMConstants.C_MassUp;
+  Curvature_Quark_F2H1[6][3][0]  = 0.1e1 / vh * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[6][3][1]  = II / vh * SMConstants.C_MassDown * V11;
+  Curvature_Quark_F2H1[6][4][0]  = 0.1e1 / vh * SMConstants.C_MassStrange * V12;
+  Curvature_Quark_F2H1[6][4][1]  = II / vh * SMConstants.C_MassStrange * V12;
+  Curvature_Quark_F2H1[6][5][0]  = V13 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[6][5][1]  = II / vh * SMConstants.C_MassBottom * V13;
+  Curvature_Quark_F2H1[7][1][2]  = -II / vh * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[7][1][3]  = 0.1e1 / vh * SMConstants.C_MassCharm;
+  Curvature_Quark_F2H1[7][3][0]  = V21 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[7][3][1]  = II * V21 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[7][4][0]  = V22 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][4][1]  = II * V22 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[7][5][0]  = V23 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[7][5][1]  = II / vh * SMConstants.C_MassBottom * V23;
+  Curvature_Quark_F2H1[8][2][2]  = -II / vh * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[8][2][3]  = 0.1e1 / vh * SMConstants.C_MassTop;
+  Curvature_Quark_F2H1[8][3][0]  = 0.1e1 / vh * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[8][3][1]  = II / vh * SMConstants.C_MassDown * V31;
+  Curvature_Quark_F2H1[8][4][0]  = 0.1e1 / vh * SMConstants.C_MassStrange * V32;
+  Curvature_Quark_F2H1[8][4][1]  = II / vh * SMConstants.C_MassStrange * V32;
+  Curvature_Quark_F2H1[8][5][0]  = V33 / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[8][5][1]  = II / vh * SMConstants.C_MassBottom * V33;
+  Curvature_Quark_F2H1[9][0][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V11);
+  Curvature_Quark_F2H1[9][0][1] = II / vh * SMConstants.C_MassUp * conj(V11);
+  Curvature_Quark_F2H1[9][1][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V21);
+  Curvature_Quark_F2H1[9][1][1] = II / vh * SMConstants.C_MassCharm * conj(V21);
+  Curvature_Quark_F2H1[9][2][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V31);
+  Curvature_Quark_F2H1[9][2][1] = II / vh * SMConstants.C_MassTop * conj(V31);
+  Curvature_Quark_F2H1[9][3][2] = II / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[9][3][3] = 0.1e1 / vh * SMConstants.C_MassDown;
+  Curvature_Quark_F2H1[10][0][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V12);
+  Curvature_Quark_F2H1[10][0][1] = II / vh * SMConstants.C_MassUp * conj(V12);
+  Curvature_Quark_F2H1[10][1][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V22);
+  Curvature_Quark_F2H1[10][1][1] =
+      II / vh * SMConstants.C_MassCharm * conj(V22);
+  Curvature_Quark_F2H1[10][2][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V32);
+  Curvature_Quark_F2H1[10][2][1] = II / vh * SMConstants.C_MassTop * conj(V32);
+  Curvature_Quark_F2H1[10][4][2] = II / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[10][4][3] = 0.1e1 / vh * SMConstants.C_MassStrange;
+  Curvature_Quark_F2H1[11][0][0] =
+      -0.1e1 / vh * SMConstants.C_MassUp * conj(V13);
+  Curvature_Quark_F2H1[11][0][1] = II / vh * SMConstants.C_MassUp * conj(V13);
+  Curvature_Quark_F2H1[11][1][0] =
+      -0.1e1 / vh * SMConstants.C_MassCharm * conj(V23);
+  Curvature_Quark_F2H1[11][1][1] =
+      II / vh * SMConstants.C_MassCharm * conj(V23);
+  Curvature_Quark_F2H1[11][2][0] =
+      -0.1e1 / vh * SMConstants.C_MassTop * conj(V33);
+  Curvature_Quark_F2H1[11][2][1] = II / vh * SMConstants.C_MassTop * conj(V33);
+  Curvature_Quark_F2H1[11][5][2] = II / vh * SMConstants.C_MassBottom;
+  Curvature_Quark_F2H1[11][5][3] = 0.1e1 / vh * SMConstants.C_MassBottom;
 
   SetCurvatureDone = true;
 }

--- a/src/models/ClassPotentialCxSM.cpp
+++ b/src/models/ClassPotentialCxSM.cpp
@@ -25,7 +25,8 @@ namespace Models
  * Lagrangian parameters AFTER using the tadpole conditions), nParCT (number of
  * counterterms) as well as nVEV (number of VEVs for minimization)
  */
-Class_CxSM::Class_CxSM()
+Class_CxSM::Class_CxSM(const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   Model = ModelID::ModelIDs::CXSM; // global int constant which will be used to
                                    // tell the program which model is called

--- a/src/models/ClassPotentialOrigin.cpp
+++ b/src/models/ClassPotentialOrigin.cpp
@@ -25,7 +25,10 @@ using namespace Eigen;
 
 namespace BSMPT
 {
-Class_Potential_Origin::Class_Potential_Origin()
+Class_Potential_Origin::Class_Potential_Origin(const ISMConstants &smConstants)
+    : SMConstants{smConstants}
+    , scale{SMConstants.C_vev0}
+
 {
   // TODO Auto-generated constructor stub
 }
@@ -3510,8 +3513,8 @@ void Class_Potential_Origin::CheckImplementation(
       ModelTests::CheckNumberOfTripleCouplings(*this)));
 
   TestNames.push_back("CKM matrix unitarity");
-  TestResults.push_back(
-      ModelTests::TestResultsToString(ModelTests::CheckCKMUnitarity()));
+  TestResults.push_back(ModelTests::TestResultsToString(
+      ModelTests::CheckCKMUnitarity(SMConstants)));
 
   Logger::Write(LoggingLevel::Default,
                 "This function calculates the masses of the gauge bosons, "

--- a/src/models/ClassPotentialOrigin.cpp
+++ b/src/models/ClassPotentialOrigin.cpp
@@ -3215,12 +3215,12 @@ double Class_Potential_Origin::V1Loop(const std::vector<double> &v,
   return res;
 }
 
-void Class_Potential_Origin::CalculateDebye()
+void Class_Potential_Origin::CalculateDebye(bool forceCalculation)
 {
   if (!SetCurvatureDone) SetCurvatureArrays();
 
-  bool Done = CalculateDebyeSimplified();
-  if (!Done)
+  bool Calculate = forceCalculation or not CalculateDebyeSimplified();
+  if (Calculate)
   {
     for (std::size_t i = 0; i < NHiggs; i++)
     {

--- a/src/models/ClassPotentialR2HDM.cpp
+++ b/src/models/ClassPotentialR2HDM.cpp
@@ -181,16 +181,19 @@ void Class_Potential_R2HDM::ReadAndSet(const std::string &linestr,
   C_CosBeta        = sqrt(C_CosBetaSquared);
   C_SinBetaSquared = TanBeta * TanBeta * C_CosBetaSquared;
   C_SinBeta        = sqrt(C_SinBetaSquared);
-  //	L1 =1.0 / (C_vev0 * C_vev0 * C_CosBeta * C_CosBeta)* (ca * ca * MH * MH +
-  // sa * sa * Mh * Mh- RealMMix * C_SinBeta / C_CosBeta); 	L2 =1.0 / (C_vev0 *
-  // C_vev0 * C_SinBeta * C_SinBeta)* (sa * sa * MH * MH + ca * ca * Mh * Mh-
-  // RealMMix * C_CosBeta / C_SinBeta); 	L3 = 2 * MHP * MHP / (C_vev0 *
-  // C_vev0)+ sa * ca * (MH * MH - Mh * Mh)/ (C_vev0 * C_vev0
-  // *C_CosBeta*C_SinBeta )- RealMMix / (C_vev0 * C_vev0 * C_SinBeta *
-  // C_CosBeta); 	L4 = (MA * MA - 2 * MHP * MHP) / (C_vev0 * C_vev0)+ RealMMix /
-  // (C_vev0 * C_vev0 * C_SinBeta * C_CosBeta); 	RL5 = RealMMix / (C_vev0 *
-  // C_vev0 * C_SinBeta * C_CosBeta) - MA
-  //* MA / (C_vev0 * C_vev0);
+  //	L1 =1.0 / (SMConstants.C_vev0 * SMConstants.C_vev0 * C_CosBeta *
+  // C_CosBeta)* (ca * ca * MH * MH +
+  // sa * sa * Mh * Mh- RealMMix * C_SinBeta / C_CosBeta); 	L2 =1.0 /
+  // (SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBeta * C_SinBeta)* (sa * sa
+  // * MH * MH + ca * ca * Mh * Mh- RealMMix * C_CosBeta / C_SinBeta); 	L3 = 2
+  // * MHP * MHP / (SMConstants.C_vev0 * SMConstants.C_vev0)+ sa * ca * (MH * MH
+  // - Mh * Mh)/ (SMConstants.C_vev0 * SMConstants.C_vev0 *C_CosBeta*C_SinBeta
+  // )- RealMMix / (SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBeta *
+  // C_CosBeta); 	L4 = (MA * MA - 2 * MHP * MHP) / (SMConstants.C_vev0 *
+  // SMConstants.C_vev0)+ RealMMix / (SMConstants.C_vev0 * SMConstants.C_vev0 *
+  // C_SinBeta * C_CosBeta); 	RL5 = RealMMix / (SMConstants.C_vev0 *
+  // SMConstants.C_vev0 * C_SinBeta * C_CosBeta) - MA
+  //* MA / (SMConstants.C_vev0 * SMConstants.C_vev0);
 
   par[6] = TanBeta;
   par[4] = RL5;
@@ -212,7 +215,7 @@ void Class_Potential_R2HDM::set_gen(const std::vector<double> &par)
 {
 
   // double *p = (double *)par;
-  scale = C_vev0;
+  scale = SMConstants.C_vev0;
   //	scale=C_MassZ;
   L1               = par[0];
   L2               = par[1];
@@ -234,32 +237,44 @@ void Class_Potential_R2HDM::set_gen(const std::vector<double> &par)
   }
 
   u1 = RealMMix * TanBeta -
-       C_vev0 * C_vev0 * C_SinBetaSquared * (L4 + RL5 + L3) / 0.2e1 -
-       C_vev0 * C_vev0 * C_CosBetaSquared * L1 / 0.2e1;
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBetaSquared *
+           (L4 + RL5 + L3) / 0.2e1 -
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_CosBetaSquared * L1 / 0.2e1;
   u2 = RealMMix * 1.0 / TanBeta -
-       C_vev0 * C_vev0 * C_CosBetaSquared * (L4 + RL5 + L3) / 0.2e1 -
-       C_vev0 * C_vev0 * C_SinBetaSquared * L2 / 0.2e1;
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_CosBetaSquared *
+           (L4 + RL5 + L3) / 0.2e1 -
+       SMConstants.C_vev0 * SMConstants.C_vev0 * C_SinBetaSquared * L2 / 0.2e1;
 
-  //	double ML5 = 2*RealMMix/(C_vev0*C_vev0*C_SinBeta*C_CosBeta);
+  //	double ML5 =
+  // 2*RealMMix/(SMConstants.C_vev0*SMConstants.C_vev0*C_SinBeta*C_CosBeta);
   //	double TripleHiggs =
-  //-3.0/(C_vev0*std::sin(2*beta))*(Mh*Mh*(2*std::cos(alpha+beta)+std::sin(2*alpha)*std::sin(beta-alpha))
-  //- std::cos(alpha+beta)*std::pow(std::cos(beta-alpha),2)*C_vev0*C_vev0*ML5 );
+  //-3.0/(SMConstants.C_vev0*std::sin(2*beta))*(Mh*Mh*(2*std::cos(alpha+beta)+std::sin(2*alpha)*std::sin(beta-alpha))
+  //-
+  // std::cos(alpha+beta)*std::pow(std::cos(beta-alpha),2)*SMConstants.C_vev0*SMConstants.C_vev0*ML5
+  //);
 
   double cb = 0;
 
   if (Type == 1 or Type == 3) // Type I 2HDM oder Lepton Specific
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_SinBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_SinBeta);
   }
   if (Type == 2 or Type == 4) // Type II 2HDM oder Flipped
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_CosBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_CosBeta);
   }
   CTempC1 = 1.0 / 48 *
-            (12 * L1 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs));
-  double ct = std::sqrt(2) * C_MassTop / (C_vev0 * C_SinBeta);
-  CTempC2   = 1.0 / 48 *
-            (12 * L2 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs) +
+            (12 * L1 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs));
+  double ct =
+      std::sqrt(2) * SMConstants.C_MassTop / (SMConstants.C_vev0 * C_SinBeta);
+  CTempC2 = 1.0 / 48 *
+            (12 * L2 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs) +
              12 * ct * ct);
 
   if (Type == 1 or Type == 3)
@@ -273,8 +288,8 @@ void Class_Potential_R2HDM::set_gen(const std::vector<double> &par)
 
   vevTreeMin.resize(nVEV);
   vevTreeMin[0] = 0;
-  vevTreeMin[1] = C_vev0 * C_CosBeta;
-  vevTreeMin[2] = C_vev0 * C_SinBeta;
+  vevTreeMin[1] = SMConstants.C_vev0 * C_CosBeta;
+  vevTreeMin[2] = SMConstants.C_vev0 * C_SinBeta;
   vevTreeMin[3] = 0;
   vevTree.resize(NHiggs);
   vevTree = MinimizeOrderVEV(vevTreeMin);
@@ -512,8 +527,8 @@ void Class_Potential_R2HDM::write() const
 
   ss << "The parameters are : \n";
   ss << "Model = " << Model << "\n";
-  ss << "v1 = " << C_vev0 * C_CosBeta << "\n";
-  ss << "v2 = " << C_vev0 * C_SinBeta << "\n";
+  ss << "v1 = " << SMConstants.C_vev0 * C_CosBeta << "\n";
+  ss << "v2 = " << SMConstants.C_vev0 * C_SinBeta << "\n";
   ss << "Type = " << Type << "\n";
 
   ss << "beta = " << beta << std::endl;
@@ -637,8 +652,8 @@ std::vector<double> Class_Potential_R2HDM::calc_CT() const
   WeinbergNabla = WeinbergFirstDerivative();
   WeinbergHesse = WeinbergSecondDerivative();
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
 
   VectorXd NablaWeinberg(8);
   MatrixXd HesseWeinberg(8, 8), HiggsRot(8, 8);
@@ -878,8 +893,8 @@ void Class_Potential_R2HDM::SetCurvatureArrays()
     }
   }
 
-  HiggsVev[4] = C_vev0 * C_CosBeta;
-  HiggsVev[6] = C_vev0 * C_SinBeta;
+  HiggsVev[4] = SMConstants.C_vev0 * C_CosBeta;
+  HiggsVev[6] = SMConstants.C_vev0 * C_SinBeta;
 
   Curvature_Higgs_L2[0][0] = u1;
   Curvature_Higgs_L2[0][1] = 0;
@@ -1080,102 +1095,126 @@ void Class_Potential_R2HDM::SetCurvatureArrays()
     }
   }
 
-  Curvature_Gauge_G2H2[0][0][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[0][0][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[0][3][0][4] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][1][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][2][6] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][3][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][4][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][5][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][6][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[0][3][7][3] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][0][4] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][1][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][2][6] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][3][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][4][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][5][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][6][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][7][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
 
-  Curvature_Gauge_G2H2[1][1][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[1][1][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[1][3][0][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][1][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][2][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][3][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][4][1] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][5][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][6][3] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[1][3][7][2] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][0][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][1][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][2][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][3][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][4][1] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][5][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][6][3] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][7][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
 
-  Curvature_Gauge_G2H2[2][2][0][0] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][1][1] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][2][2] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][3][3] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][4][4] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][5][5] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][6][6] = C_g * C_g / 0.2e1;
-  Curvature_Gauge_G2H2[2][2][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
 
-  Curvature_Gauge_G2H2[2][3][0][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][1][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][2][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][3][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][4][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][5][5] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][6][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[2][3][7][7] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][0][4] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][1][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][2][6] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][3][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][4][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][5][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][6][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][0][7][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][0][5] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][1][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][2][7] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][3][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][4][1] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][5][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][6][3] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][1][7][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][0][0] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][1][1] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][2][2] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][3][3] = C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][4][4] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][5][5] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][6][6] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][2][7][7] = -C_g * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][0][0] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][1][1] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][2][2] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][3][3] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][4][4] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][5][5] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][6][6] = C_gs * C_gs / 0.2e1;
-  Curvature_Gauge_G2H2[3][3][7][7] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][0][4] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][1][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][2][6] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][3][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][4][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][5][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][6][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][7][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][0][5] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][1][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][2][7] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][3][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][4][1] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][5][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][6][3] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][7][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][0][0] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][1][1] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][2][2] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][3][3] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][4][4] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][5][5] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][6][6] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][7][7] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
 
   std::complex<double> V11, V12, V13, V21, V22, V23, V31, V32, V33;
-  V11 = C_Vud;
-  V12 = C_Vus;
-  V13 = C_Vub;
-  V21 = C_Vcd;
-  V22 = C_Vcs;
-  V23 = C_Vcb;
-  V31 = C_Vtd;
-  V32 = C_Vts;
-  V33 = C_Vtb;
+  V11 = SMConstants.C_Vud;
+  V12 = SMConstants.C_Vus;
+  V13 = SMConstants.C_Vub;
+  V21 = SMConstants.C_Vcd;
+  V22 = SMConstants.C_Vcs;
+  V23 = SMConstants.C_Vcb;
+  V31 = SMConstants.C_Vtd;
+  V32 = SMConstants.C_Vts;
+  V33 = SMConstants.C_Vtb;
 
   MatrixXcd YIJR2(NQuarks, NQuarks), YIJE2(NQuarks, NQuarks),
       YIJS2(NQuarks, NQuarks), YIJP2(NQuarks, NQuarks), YIJRD(NQuarks, NQuarks),
@@ -1195,8 +1234,8 @@ void Class_Potential_R2HDM::SetCurvatureArrays()
   YIJSL = MatrixXcd::Zero(NLepton, NLepton);
   YIJPL = MatrixXcd::Zero(NLepton, NLepton);
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
   double vL = v2;
   double vD = v2;
   if (Type == 2)
@@ -1209,43 +1248,43 @@ void Class_Potential_R2HDM::SetCurvatureArrays()
   else if (Type == 4)
     vD = v1;
 
-  YIJR2(0, 9)  = -std::conj(V11) * C_MassUp / v2;
-  YIJR2(0, 10) = -std::conj(V12) * C_MassUp / v2;
-  YIJR2(0, 11) = -std::conj(V13) * C_MassUp / v2;
+  YIJR2(0, 9)  = -std::conj(V11) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 10) = -std::conj(V12) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 11) = -std::conj(V13) * SMConstants.C_MassUp / v2;
 
-  YIJR2(1, 9)  = -std::conj(V21) * C_MassCharm / v2;
-  YIJR2(1, 10) = -std::conj(V22) * C_MassCharm / v2;
-  YIJR2(1, 11) = -std::conj(V23) * C_MassCharm / v2;
+  YIJR2(1, 9)  = -std::conj(V21) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 10) = -std::conj(V22) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 11) = -std::conj(V23) * SMConstants.C_MassCharm / v2;
 
-  YIJR2(2, 9)  = -std::conj(V31) * C_MassTop / v2;
-  YIJR2(2, 10) = -std::conj(V32) * C_MassTop / v2;
-  YIJR2(2, 11) = -std::conj(V33) * C_MassTop / v2;
+  YIJR2(2, 9)  = -std::conj(V31) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 10) = -std::conj(V32) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 11) = -std::conj(V33) * SMConstants.C_MassTop / v2;
 
-  YIJS2(0, 6) = C_MassUp / v2;
-  YIJS2(1, 7) = C_MassCharm / v2;
-  YIJS2(2, 8) = C_MassTop / v2;
+  YIJS2(0, 6) = SMConstants.C_MassUp / v2;
+  YIJS2(1, 7) = SMConstants.C_MassCharm / v2;
+  YIJS2(2, 8) = SMConstants.C_MassTop / v2;
 
-  YIJSD(3, 9)  = C_MassDown / vD;
-  YIJSD(4, 10) = C_MassStrange / vD;
-  YIJSD(5, 11) = C_MassBottom / vD;
+  YIJSD(3, 9)  = SMConstants.C_MassDown / vD;
+  YIJSD(4, 10) = SMConstants.C_MassStrange / vD;
+  YIJSD(5, 11) = SMConstants.C_MassBottom / vD;
 
-  YIJRD(3, 6) = V11 * C_MassDown / vD;
-  YIJRD(3, 7) = V21 * C_MassDown / vD;
-  YIJRD(3, 8) = V31 * C_MassDown / vD;
-  YIJRD(4, 6) = V12 * C_MassStrange / vD;
-  YIJRD(4, 7) = V22 * C_MassStrange / vD;
-  YIJRD(4, 8) = V32 * C_MassStrange / vD;
-  YIJRD(5, 6) = V13 * C_MassBottom / vD;
-  YIJRD(5, 7) = V23 * C_MassBottom / vD;
-  YIJRD(5, 8) = V33 * C_MassBottom / vD;
+  YIJRD(3, 6) = V11 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 7) = V21 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 8) = V31 * SMConstants.C_MassDown / vD;
+  YIJRD(4, 6) = V12 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 7) = V22 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 8) = V32 * SMConstants.C_MassStrange / vD;
+  YIJRD(5, 6) = V13 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 7) = V23 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 8) = V33 * SMConstants.C_MassBottom / vD;
 
-  YIJRL(1, 6) = C_MassElectron / vL;
-  YIJRL(3, 7) = C_MassMu / vL;
-  YIJRL(5, 8) = C_MassTau / vL;
+  YIJRL(1, 6) = SMConstants.C_MassElectron / vL;
+  YIJRL(3, 7) = SMConstants.C_MassMu / vL;
+  YIJRL(5, 8) = SMConstants.C_MassTau / vL;
 
-  YIJSL(0, 1) = C_MassElectron / vL;
-  YIJSL(2, 3) = C_MassMu / vL;
-  YIJSL(4, 5) = C_MassTau / vL;
+  YIJSL(0, 1) = SMConstants.C_MassElectron / vL;
+  YIJSL(2, 3) = SMConstants.C_MassMu / vL;
+  YIJSL(4, 5) = SMConstants.C_MassTau / vL;
 
   for (std::size_t i = 0; i < NQuarks; i++)
   {
@@ -1343,17 +1382,24 @@ bool Class_Potential_R2HDM::CalculateDebyeSimplified()
 
   if (Type == 1 or Type == 3) // Type I 2HDM oder Lepton Specific
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_SinBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_SinBeta);
   }
   if (Type == 2 or Type == 4) // Type II 2HDM oder Flipped
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_CosBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_CosBeta);
   }
   CTempC1 = 1.0 / 48 *
-            (12 * L1 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs));
-  double ct = std::sqrt(2) * C_MassTop / (C_vev0 * C_SinBeta);
-  CTempC2   = 1.0 / 48 *
-            (12 * L2 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs) +
+            (12 * L1 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs));
+  double ct =
+      std::sqrt(2) * SMConstants.C_MassTop / (SMConstants.C_vev0 * C_SinBeta);
+  CTempC2 = 1.0 / 48 *
+            (12 * L2 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs) +
              12 * ct * ct);
 
   if (Type == 1 or Type == 3)
@@ -1379,10 +1425,10 @@ bool Class_Potential_R2HDM::CalculateDebyeSimplified()
 
 bool Class_Potential_R2HDM::CalculateDebyeGaugeSimplified()
 {
-  DebyeGauge[0][0] = 2 * C_g * C_g;
-  DebyeGauge[1][1] = 2 * C_g * C_g;
-  DebyeGauge[2][2] = 2 * C_g * C_g;
-  DebyeGauge[3][3] = 2 * C_gs * C_gs;
+  DebyeGauge[0][0] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[1][1] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[2][2] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[3][3] = 2 * SMConstants.C_gs * SMConstants.C_gs;
 
   return true;
 }

--- a/src/models/ClassPotentialR2HDM.cpp
+++ b/src/models/ClassPotentialR2HDM.cpp
@@ -14,7 +14,8 @@ namespace BSMPT
 namespace Models
 {
 
-Class_Potential_R2HDM::Class_Potential_R2HDM()
+Class_Potential_R2HDM::Class_Potential_R2HDM(const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   // TODO Auto-generated constructor stub
   Model         = ModelID::ModelIDs::R2HDM;

--- a/src/models/ClassPotentialRN2HDM.cpp
+++ b/src/models/ClassPotentialRN2HDM.cpp
@@ -232,7 +232,7 @@ void Class_Potential_RN2HDM::set_gen(const std::vector<double> &p)
   TanBeta  = p[8];
   Nvs      = p[9];
   RealMMix = p[10];
-  scale    = C_vev0;
+  scale    = SMConstants.C_vev0;
   Type     = p[11];
 
   C_CosBetaSquared = 1.0 / (1 + TanBeta * TanBeta);
@@ -241,8 +241,8 @@ void Class_Potential_RN2HDM::set_gen(const std::vector<double> &p)
   C_SinBeta        = sqrt(C_SinBetaSquared);
   beta             = std::atan(TanBeta);
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
 
   u1 = RealMMix * TanBeta - 0.5 * v1 * v1 * L1 -
        0.5 * v2 * v2 * (L3 + L4 + RL5) - 0.5 * Nvs * Nvs * NL7;
@@ -253,8 +253,8 @@ void Class_Potential_RN2HDM::set_gen(const std::vector<double> &p)
   vevTreeMin.resize(nVEV);
   vevTreeMin[0] = 0;
   vevTreeMin[1] = 0;
-  vevTreeMin[2] = C_vev0 * C_CosBeta;
-  vevTreeMin[3] = C_vev0 * C_SinBeta;
+  vevTreeMin[2] = SMConstants.C_vev0 * C_CosBeta;
+  vevTreeMin[3] = SMConstants.C_vev0 * C_SinBeta;
   vevTreeMin[4] = Nvs;
   vevTree.resize(NHiggs);
   vevTree = MinimizeOrderVEV(vevTreeMin);
@@ -443,8 +443,8 @@ void Class_Potential_RN2HDM::write() const
   ss << "The parameters are :   \n";
   ss << "Model = " << Model << "\n";
   ss << "Renorm Scale = " << scale << "\n";
-  ss << "v1 = " << C_vev0 * C_CosBeta << "\n";
-  ss << "v2 = " << C_vev0 * C_SinBeta << "\n";
+  ss << "v1 = " << SMConstants.C_vev0 * C_CosBeta << "\n";
+  ss << "v2 = " << SMConstants.C_vev0 * C_SinBeta << "\n";
   ss << "Type = " << Type << "\n";
 
   ss << "beta = " << beta << std::endl;
@@ -638,8 +638,8 @@ std::vector<double> Class_Potential_RN2HDM::calc_CT() const
   WeinbergNabla = WeinbergFirstDerivative();
   WeinbergHesse = WeinbergSecondDerivative();
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
 
   VectorXd NablaWeinberg(NHiggs);
   MatrixXd HesseWeinberg(NHiggs, NHiggs), HiggsRot(NHiggs, NHiggs);
@@ -959,8 +959,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
     }
   }
 
-  HiggsVev[6]              = C_vev0 * C_CosBeta;
-  HiggsVev[7]              = C_vev0 * C_SinBeta;
+  HiggsVev[6]              = SMConstants.C_vev0 * C_CosBeta;
+  HiggsVev[7]              = SMConstants.C_vev0 * C_SinBeta;
   HiggsVev[8]              = Nvs;
   Curvature_Higgs_L2[0][0] = u1;
   Curvature_Higgs_L2[0][1] = -RealMMix;
@@ -1611,7 +1611,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
     }
   }
 
-  Curvature_Gauge_G2H2[0][0][0][0] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][0][1] = 0;
   Curvature_Gauge_G2H2[0][0][0][2] = 0;
   Curvature_Gauge_G2H2[0][0][0][3] = 0;
@@ -1621,7 +1621,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][0][7] = 0;
   Curvature_Gauge_G2H2[0][0][0][8] = 0;
   Curvature_Gauge_G2H2[0][0][1][0] = 0;
-  Curvature_Gauge_G2H2[0][0][1][1] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][1][2] = 0;
   Curvature_Gauge_G2H2[0][0][1][3] = 0;
   Curvature_Gauge_G2H2[0][0][1][4] = 0;
@@ -1631,7 +1631,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][1][8] = 0;
   Curvature_Gauge_G2H2[0][0][2][0] = 0;
   Curvature_Gauge_G2H2[0][0][2][1] = 0;
-  Curvature_Gauge_G2H2[0][0][2][2] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][2][3] = 0;
   Curvature_Gauge_G2H2[0][0][2][4] = 0;
   Curvature_Gauge_G2H2[0][0][2][5] = 0;
@@ -1641,7 +1641,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][3][0] = 0;
   Curvature_Gauge_G2H2[0][0][3][1] = 0;
   Curvature_Gauge_G2H2[0][0][3][2] = 0;
-  Curvature_Gauge_G2H2[0][0][3][3] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][3][4] = 0;
   Curvature_Gauge_G2H2[0][0][3][5] = 0;
   Curvature_Gauge_G2H2[0][0][3][6] = 0;
@@ -1651,7 +1651,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][4][1] = 0;
   Curvature_Gauge_G2H2[0][0][4][2] = 0;
   Curvature_Gauge_G2H2[0][0][4][3] = 0;
-  Curvature_Gauge_G2H2[0][0][4][4] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][4][5] = 0;
   Curvature_Gauge_G2H2[0][0][4][6] = 0;
   Curvature_Gauge_G2H2[0][0][4][7] = 0;
@@ -1661,7 +1661,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][5][2] = 0;
   Curvature_Gauge_G2H2[0][0][5][3] = 0;
   Curvature_Gauge_G2H2[0][0][5][4] = 0;
-  Curvature_Gauge_G2H2[0][0][5][5] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][5][6] = 0;
   Curvature_Gauge_G2H2[0][0][5][7] = 0;
   Curvature_Gauge_G2H2[0][0][5][8] = 0;
@@ -1671,7 +1671,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][6][3] = 0;
   Curvature_Gauge_G2H2[0][0][6][4] = 0;
   Curvature_Gauge_G2H2[0][0][6][5] = 0;
-  Curvature_Gauge_G2H2[0][0][6][6] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][6][7] = 0;
   Curvature_Gauge_G2H2[0][0][6][8] = 0;
   Curvature_Gauge_G2H2[0][0][7][0] = 0;
@@ -1681,7 +1681,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][0][7][4] = 0;
   Curvature_Gauge_G2H2[0][0][7][5] = 0;
   Curvature_Gauge_G2H2[0][0][7][6] = 0;
-  Curvature_Gauge_G2H2[0][0][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][0][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][0][7][8] = 0;
   Curvature_Gauge_G2H2[0][0][8][0] = 0;
   Curvature_Gauge_G2H2[0][0][8][1] = 0;
@@ -1860,7 +1860,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][3][0][3] = 0;
   Curvature_Gauge_G2H2[0][3][0][4] = 0;
   Curvature_Gauge_G2H2[0][3][0][5] = 0;
-  Curvature_Gauge_G2H2[0][3][0][6] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][0][6] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][0][7] = 0;
   Curvature_Gauge_G2H2[0][3][0][8] = 0;
   Curvature_Gauge_G2H2[0][3][1][0] = 0;
@@ -1870,13 +1870,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][3][1][4] = 0;
   Curvature_Gauge_G2H2[0][3][1][5] = 0;
   Curvature_Gauge_G2H2[0][3][1][6] = 0;
-  Curvature_Gauge_G2H2[0][3][1][7] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][1][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][1][8] = 0;
   Curvature_Gauge_G2H2[0][3][2][0] = 0;
   Curvature_Gauge_G2H2[0][3][2][1] = 0;
   Curvature_Gauge_G2H2[0][3][2][2] = 0;
   Curvature_Gauge_G2H2[0][3][2][3] = 0;
-  Curvature_Gauge_G2H2[0][3][2][4] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][2][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][2][5] = 0;
   Curvature_Gauge_G2H2[0][3][2][6] = 0;
   Curvature_Gauge_G2H2[0][3][2][7] = 0;
@@ -1886,13 +1886,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][3][3][2] = 0;
   Curvature_Gauge_G2H2[0][3][3][3] = 0;
   Curvature_Gauge_G2H2[0][3][3][4] = 0;
-  Curvature_Gauge_G2H2[0][3][3][5] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][3][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][3][6] = 0;
   Curvature_Gauge_G2H2[0][3][3][7] = 0;
   Curvature_Gauge_G2H2[0][3][3][8] = 0;
   Curvature_Gauge_G2H2[0][3][4][0] = 0;
   Curvature_Gauge_G2H2[0][3][4][1] = 0;
-  Curvature_Gauge_G2H2[0][3][4][2] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][4][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][4][3] = 0;
   Curvature_Gauge_G2H2[0][3][4][4] = 0;
   Curvature_Gauge_G2H2[0][3][4][5] = 0;
@@ -1902,13 +1902,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][3][5][0] = 0;
   Curvature_Gauge_G2H2[0][3][5][1] = 0;
   Curvature_Gauge_G2H2[0][3][5][2] = 0;
-  Curvature_Gauge_G2H2[0][3][5][3] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][5][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][5][4] = 0;
   Curvature_Gauge_G2H2[0][3][5][5] = 0;
   Curvature_Gauge_G2H2[0][3][5][6] = 0;
   Curvature_Gauge_G2H2[0][3][5][7] = 0;
   Curvature_Gauge_G2H2[0][3][5][8] = 0;
-  Curvature_Gauge_G2H2[0][3][6][0] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][6][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][6][1] = 0;
   Curvature_Gauge_G2H2[0][3][6][2] = 0;
   Curvature_Gauge_G2H2[0][3][6][3] = 0;
@@ -1918,7 +1918,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[0][3][6][7] = 0;
   Curvature_Gauge_G2H2[0][3][6][8] = 0;
   Curvature_Gauge_G2H2[0][3][7][0] = 0;
-  Curvature_Gauge_G2H2[0][3][7][1] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[0][3][7][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[0][3][7][2] = 0;
   Curvature_Gauge_G2H2[0][3][7][3] = 0;
   Curvature_Gauge_G2H2[0][3][7][4] = 0;
@@ -2016,7 +2016,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][0][8][6] = 0;
   Curvature_Gauge_G2H2[1][0][8][7] = 0;
   Curvature_Gauge_G2H2[1][0][8][8] = 0;
-  Curvature_Gauge_G2H2[1][1][0][0] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][0][1] = 0;
   Curvature_Gauge_G2H2[1][1][0][2] = 0;
   Curvature_Gauge_G2H2[1][1][0][3] = 0;
@@ -2026,7 +2026,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][0][7] = 0;
   Curvature_Gauge_G2H2[1][1][0][8] = 0;
   Curvature_Gauge_G2H2[1][1][1][0] = 0;
-  Curvature_Gauge_G2H2[1][1][1][1] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][1][2] = 0;
   Curvature_Gauge_G2H2[1][1][1][3] = 0;
   Curvature_Gauge_G2H2[1][1][1][4] = 0;
@@ -2036,7 +2036,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][1][8] = 0;
   Curvature_Gauge_G2H2[1][1][2][0] = 0;
   Curvature_Gauge_G2H2[1][1][2][1] = 0;
-  Curvature_Gauge_G2H2[1][1][2][2] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][2][3] = 0;
   Curvature_Gauge_G2H2[1][1][2][4] = 0;
   Curvature_Gauge_G2H2[1][1][2][5] = 0;
@@ -2046,7 +2046,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][3][0] = 0;
   Curvature_Gauge_G2H2[1][1][3][1] = 0;
   Curvature_Gauge_G2H2[1][1][3][2] = 0;
-  Curvature_Gauge_G2H2[1][1][3][3] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][3][4] = 0;
   Curvature_Gauge_G2H2[1][1][3][5] = 0;
   Curvature_Gauge_G2H2[1][1][3][6] = 0;
@@ -2056,7 +2056,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][4][1] = 0;
   Curvature_Gauge_G2H2[1][1][4][2] = 0;
   Curvature_Gauge_G2H2[1][1][4][3] = 0;
-  Curvature_Gauge_G2H2[1][1][4][4] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][4][5] = 0;
   Curvature_Gauge_G2H2[1][1][4][6] = 0;
   Curvature_Gauge_G2H2[1][1][4][7] = 0;
@@ -2066,7 +2066,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][5][2] = 0;
   Curvature_Gauge_G2H2[1][1][5][3] = 0;
   Curvature_Gauge_G2H2[1][1][5][4] = 0;
-  Curvature_Gauge_G2H2[1][1][5][5] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][5][6] = 0;
   Curvature_Gauge_G2H2[1][1][5][7] = 0;
   Curvature_Gauge_G2H2[1][1][5][8] = 0;
@@ -2076,7 +2076,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][6][3] = 0;
   Curvature_Gauge_G2H2[1][1][6][4] = 0;
   Curvature_Gauge_G2H2[1][1][6][5] = 0;
-  Curvature_Gauge_G2H2[1][1][6][6] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][6][7] = 0;
   Curvature_Gauge_G2H2[1][1][6][8] = 0;
   Curvature_Gauge_G2H2[1][1][7][0] = 0;
@@ -2086,7 +2086,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][1][7][4] = 0;
   Curvature_Gauge_G2H2[1][1][7][5] = 0;
   Curvature_Gauge_G2H2[1][1][7][6] = 0;
-  Curvature_Gauge_G2H2[1][1][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][1][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][1][7][8] = 0;
   Curvature_Gauge_G2H2[1][1][8][0] = 0;
   Curvature_Gauge_G2H2[1][1][8][1] = 0;
@@ -2182,7 +2182,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][0][1] = 0;
   Curvature_Gauge_G2H2[1][3][0][2] = 0;
   Curvature_Gauge_G2H2[1][3][0][3] = 0;
-  Curvature_Gauge_G2H2[1][3][0][4] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][0][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][0][5] = 0;
   Curvature_Gauge_G2H2[1][3][0][6] = 0;
   Curvature_Gauge_G2H2[1][3][0][7] = 0;
@@ -2192,7 +2192,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][1][2] = 0;
   Curvature_Gauge_G2H2[1][3][1][3] = 0;
   Curvature_Gauge_G2H2[1][3][1][4] = 0;
-  Curvature_Gauge_G2H2[1][3][1][5] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][1][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][1][6] = 0;
   Curvature_Gauge_G2H2[1][3][1][7] = 0;
   Curvature_Gauge_G2H2[1][3][1][8] = 0;
@@ -2202,7 +2202,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][2][3] = 0;
   Curvature_Gauge_G2H2[1][3][2][4] = 0;
   Curvature_Gauge_G2H2[1][3][2][5] = 0;
-  Curvature_Gauge_G2H2[1][3][2][6] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][2][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][2][7] = 0;
   Curvature_Gauge_G2H2[1][3][2][8] = 0;
   Curvature_Gauge_G2H2[1][3][3][0] = 0;
@@ -2212,9 +2213,10 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][3][4] = 0;
   Curvature_Gauge_G2H2[1][3][3][5] = 0;
   Curvature_Gauge_G2H2[1][3][3][6] = 0;
-  Curvature_Gauge_G2H2[1][3][3][7] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][3][7] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][3][8] = 0;
-  Curvature_Gauge_G2H2[1][3][4][0] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][4][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][4][1] = 0;
   Curvature_Gauge_G2H2[1][3][4][2] = 0;
   Curvature_Gauge_G2H2[1][3][4][3] = 0;
@@ -2224,7 +2226,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][4][7] = 0;
   Curvature_Gauge_G2H2[1][3][4][8] = 0;
   Curvature_Gauge_G2H2[1][3][5][0] = 0;
-  Curvature_Gauge_G2H2[1][3][5][1] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][5][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][5][2] = 0;
   Curvature_Gauge_G2H2[1][3][5][3] = 0;
   Curvature_Gauge_G2H2[1][3][5][4] = 0;
@@ -2234,7 +2236,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][5][8] = 0;
   Curvature_Gauge_G2H2[1][3][6][0] = 0;
   Curvature_Gauge_G2H2[1][3][6][1] = 0;
-  Curvature_Gauge_G2H2[1][3][6][2] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][6][2] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][6][3] = 0;
   Curvature_Gauge_G2H2[1][3][6][4] = 0;
   Curvature_Gauge_G2H2[1][3][6][5] = 0;
@@ -2244,7 +2247,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[1][3][7][0] = 0;
   Curvature_Gauge_G2H2[1][3][7][1] = 0;
   Curvature_Gauge_G2H2[1][3][7][2] = 0;
-  Curvature_Gauge_G2H2[1][3][7][3] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[1][3][7][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[1][3][7][4] = 0;
   Curvature_Gauge_G2H2[1][3][7][5] = 0;
   Curvature_Gauge_G2H2[1][3][7][6] = 0;
@@ -2421,7 +2425,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][1][8][6] = 0;
   Curvature_Gauge_G2H2[2][1][8][7] = 0;
   Curvature_Gauge_G2H2[2][1][8][8] = 0;
-  Curvature_Gauge_G2H2[2][2][0][0] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][0][0] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][0][1] = 0;
   Curvature_Gauge_G2H2[2][2][0][2] = 0;
   Curvature_Gauge_G2H2[2][2][0][3] = 0;
@@ -2431,7 +2435,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][0][7] = 0;
   Curvature_Gauge_G2H2[2][2][0][8] = 0;
   Curvature_Gauge_G2H2[2][2][1][0] = 0;
-  Curvature_Gauge_G2H2[2][2][1][1] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][1][1] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][1][2] = 0;
   Curvature_Gauge_G2H2[2][2][1][3] = 0;
   Curvature_Gauge_G2H2[2][2][1][4] = 0;
@@ -2441,7 +2445,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][1][8] = 0;
   Curvature_Gauge_G2H2[2][2][2][0] = 0;
   Curvature_Gauge_G2H2[2][2][2][1] = 0;
-  Curvature_Gauge_G2H2[2][2][2][2] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][2][2] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][2][3] = 0;
   Curvature_Gauge_G2H2[2][2][2][4] = 0;
   Curvature_Gauge_G2H2[2][2][2][5] = 0;
@@ -2451,7 +2455,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][3][0] = 0;
   Curvature_Gauge_G2H2[2][2][3][1] = 0;
   Curvature_Gauge_G2H2[2][2][3][2] = 0;
-  Curvature_Gauge_G2H2[2][2][3][3] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][3][3] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][3][4] = 0;
   Curvature_Gauge_G2H2[2][2][3][5] = 0;
   Curvature_Gauge_G2H2[2][2][3][6] = 0;
@@ -2461,7 +2465,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][4][1] = 0;
   Curvature_Gauge_G2H2[2][2][4][2] = 0;
   Curvature_Gauge_G2H2[2][2][4][3] = 0;
-  Curvature_Gauge_G2H2[2][2][4][4] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][4][4] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][4][5] = 0;
   Curvature_Gauge_G2H2[2][2][4][6] = 0;
   Curvature_Gauge_G2H2[2][2][4][7] = 0;
@@ -2471,7 +2475,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][5][2] = 0;
   Curvature_Gauge_G2H2[2][2][5][3] = 0;
   Curvature_Gauge_G2H2[2][2][5][4] = 0;
-  Curvature_Gauge_G2H2[2][2][5][5] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][5][5] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][5][6] = 0;
   Curvature_Gauge_G2H2[2][2][5][7] = 0;
   Curvature_Gauge_G2H2[2][2][5][8] = 0;
@@ -2481,7 +2485,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][6][3] = 0;
   Curvature_Gauge_G2H2[2][2][6][4] = 0;
   Curvature_Gauge_G2H2[2][2][6][5] = 0;
-  Curvature_Gauge_G2H2[2][2][6][6] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][6][6] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][6][7] = 0;
   Curvature_Gauge_G2H2[2][2][6][8] = 0;
   Curvature_Gauge_G2H2[2][2][7][0] = 0;
@@ -2491,7 +2495,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][7][4] = 0;
   Curvature_Gauge_G2H2[2][2][7][5] = 0;
   Curvature_Gauge_G2H2[2][2][7][6] = 0;
-  Curvature_Gauge_G2H2[2][2][7][7] = C_g * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[2][2][7][7] = SMConstants.C_g * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[2][2][7][8] = 0;
   Curvature_Gauge_G2H2[2][2][8][0] = 0;
   Curvature_Gauge_G2H2[2][2][8][1] = 0;
@@ -2502,7 +2506,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][2][8][6] = 0;
   Curvature_Gauge_G2H2[2][2][8][7] = 0;
   Curvature_Gauge_G2H2[2][2][8][8] = 0;
-  Curvature_Gauge_G2H2[2][3][0][0] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][0][1] = 0;
   Curvature_Gauge_G2H2[2][3][0][2] = 0;
   Curvature_Gauge_G2H2[2][3][0][3] = 0;
@@ -2512,7 +2516,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][0][7] = 0;
   Curvature_Gauge_G2H2[2][3][0][8] = 0;
   Curvature_Gauge_G2H2[2][3][1][0] = 0;
-  Curvature_Gauge_G2H2[2][3][1][1] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][1][2] = 0;
   Curvature_Gauge_G2H2[2][3][1][3] = 0;
   Curvature_Gauge_G2H2[2][3][1][4] = 0;
@@ -2522,7 +2526,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][1][8] = 0;
   Curvature_Gauge_G2H2[2][3][2][0] = 0;
   Curvature_Gauge_G2H2[2][3][2][1] = 0;
-  Curvature_Gauge_G2H2[2][3][2][2] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][2][3] = 0;
   Curvature_Gauge_G2H2[2][3][2][4] = 0;
   Curvature_Gauge_G2H2[2][3][2][5] = 0;
@@ -2532,7 +2536,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][3][0] = 0;
   Curvature_Gauge_G2H2[2][3][3][1] = 0;
   Curvature_Gauge_G2H2[2][3][3][2] = 0;
-  Curvature_Gauge_G2H2[2][3][3][3] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][3][4] = 0;
   Curvature_Gauge_G2H2[2][3][3][5] = 0;
   Curvature_Gauge_G2H2[2][3][3][6] = 0;
@@ -2542,7 +2546,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][4][1] = 0;
   Curvature_Gauge_G2H2[2][3][4][2] = 0;
   Curvature_Gauge_G2H2[2][3][4][3] = 0;
-  Curvature_Gauge_G2H2[2][3][4][4] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][4][5] = 0;
   Curvature_Gauge_G2H2[2][3][4][6] = 0;
   Curvature_Gauge_G2H2[2][3][4][7] = 0;
@@ -2552,7 +2557,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][5][2] = 0;
   Curvature_Gauge_G2H2[2][3][5][3] = 0;
   Curvature_Gauge_G2H2[2][3][5][4] = 0;
-  Curvature_Gauge_G2H2[2][3][5][5] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][5][6] = 0;
   Curvature_Gauge_G2H2[2][3][5][7] = 0;
   Curvature_Gauge_G2H2[2][3][5][8] = 0;
@@ -2562,7 +2568,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][6][3] = 0;
   Curvature_Gauge_G2H2[2][3][6][4] = 0;
   Curvature_Gauge_G2H2[2][3][6][5] = 0;
-  Curvature_Gauge_G2H2[2][3][6][6] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][6][7] = 0;
   Curvature_Gauge_G2H2[2][3][6][8] = 0;
   Curvature_Gauge_G2H2[2][3][7][0] = 0;
@@ -2572,7 +2579,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[2][3][7][4] = 0;
   Curvature_Gauge_G2H2[2][3][7][5] = 0;
   Curvature_Gauge_G2H2[2][3][7][6] = 0;
-  Curvature_Gauge_G2H2[2][3][7][7] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[2][3][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[2][3][7][8] = 0;
   Curvature_Gauge_G2H2[2][3][8][0] = 0;
   Curvature_Gauge_G2H2[2][3][8][1] = 0;
@@ -2589,7 +2597,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][0][0][3] = 0;
   Curvature_Gauge_G2H2[3][0][0][4] = 0;
   Curvature_Gauge_G2H2[3][0][0][5] = 0;
-  Curvature_Gauge_G2H2[3][0][0][6] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][0][6] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][0][7] = 0;
   Curvature_Gauge_G2H2[3][0][0][8] = 0;
   Curvature_Gauge_G2H2[3][0][1][0] = 0;
@@ -2599,13 +2607,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][0][1][4] = 0;
   Curvature_Gauge_G2H2[3][0][1][5] = 0;
   Curvature_Gauge_G2H2[3][0][1][6] = 0;
-  Curvature_Gauge_G2H2[3][0][1][7] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][1][7] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][1][8] = 0;
   Curvature_Gauge_G2H2[3][0][2][0] = 0;
   Curvature_Gauge_G2H2[3][0][2][1] = 0;
   Curvature_Gauge_G2H2[3][0][2][2] = 0;
   Curvature_Gauge_G2H2[3][0][2][3] = 0;
-  Curvature_Gauge_G2H2[3][0][2][4] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][2][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][2][5] = 0;
   Curvature_Gauge_G2H2[3][0][2][6] = 0;
   Curvature_Gauge_G2H2[3][0][2][7] = 0;
@@ -2615,13 +2623,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][0][3][2] = 0;
   Curvature_Gauge_G2H2[3][0][3][3] = 0;
   Curvature_Gauge_G2H2[3][0][3][4] = 0;
-  Curvature_Gauge_G2H2[3][0][3][5] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][3][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][3][6] = 0;
   Curvature_Gauge_G2H2[3][0][3][7] = 0;
   Curvature_Gauge_G2H2[3][0][3][8] = 0;
   Curvature_Gauge_G2H2[3][0][4][0] = 0;
   Curvature_Gauge_G2H2[3][0][4][1] = 0;
-  Curvature_Gauge_G2H2[3][0][4][2] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][4][2] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][4][3] = 0;
   Curvature_Gauge_G2H2[3][0][4][4] = 0;
   Curvature_Gauge_G2H2[3][0][4][5] = 0;
@@ -2631,13 +2639,13 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][0][5][0] = 0;
   Curvature_Gauge_G2H2[3][0][5][1] = 0;
   Curvature_Gauge_G2H2[3][0][5][2] = 0;
-  Curvature_Gauge_G2H2[3][0][5][3] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][5][3] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][5][4] = 0;
   Curvature_Gauge_G2H2[3][0][5][5] = 0;
   Curvature_Gauge_G2H2[3][0][5][6] = 0;
   Curvature_Gauge_G2H2[3][0][5][7] = 0;
   Curvature_Gauge_G2H2[3][0][5][8] = 0;
-  Curvature_Gauge_G2H2[3][0][6][0] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][6][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][6][1] = 0;
   Curvature_Gauge_G2H2[3][0][6][2] = 0;
   Curvature_Gauge_G2H2[3][0][6][3] = 0;
@@ -2647,7 +2655,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][0][6][7] = 0;
   Curvature_Gauge_G2H2[3][0][6][8] = 0;
   Curvature_Gauge_G2H2[3][0][7][0] = 0;
-  Curvature_Gauge_G2H2[3][0][7][1] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][0][7][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][0][7][2] = 0;
   Curvature_Gauge_G2H2[3][0][7][3] = 0;
   Curvature_Gauge_G2H2[3][0][7][4] = 0;
@@ -2668,7 +2676,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][0][1] = 0;
   Curvature_Gauge_G2H2[3][1][0][2] = 0;
   Curvature_Gauge_G2H2[3][1][0][3] = 0;
-  Curvature_Gauge_G2H2[3][1][0][4] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][0][4] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][0][5] = 0;
   Curvature_Gauge_G2H2[3][1][0][6] = 0;
   Curvature_Gauge_G2H2[3][1][0][7] = 0;
@@ -2678,7 +2686,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][1][2] = 0;
   Curvature_Gauge_G2H2[3][1][1][3] = 0;
   Curvature_Gauge_G2H2[3][1][1][4] = 0;
-  Curvature_Gauge_G2H2[3][1][1][5] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][1][5] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][1][6] = 0;
   Curvature_Gauge_G2H2[3][1][1][7] = 0;
   Curvature_Gauge_G2H2[3][1][1][8] = 0;
@@ -2688,7 +2696,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][2][3] = 0;
   Curvature_Gauge_G2H2[3][1][2][4] = 0;
   Curvature_Gauge_G2H2[3][1][2][5] = 0;
-  Curvature_Gauge_G2H2[3][1][2][6] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][2][6] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][2][7] = 0;
   Curvature_Gauge_G2H2[3][1][2][8] = 0;
   Curvature_Gauge_G2H2[3][1][3][0] = 0;
@@ -2698,9 +2707,10 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][3][4] = 0;
   Curvature_Gauge_G2H2[3][1][3][5] = 0;
   Curvature_Gauge_G2H2[3][1][3][6] = 0;
-  Curvature_Gauge_G2H2[3][1][3][7] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][3][7] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][3][8] = 0;
-  Curvature_Gauge_G2H2[3][1][4][0] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][4][0] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][4][1] = 0;
   Curvature_Gauge_G2H2[3][1][4][2] = 0;
   Curvature_Gauge_G2H2[3][1][4][3] = 0;
@@ -2710,7 +2720,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][4][7] = 0;
   Curvature_Gauge_G2H2[3][1][4][8] = 0;
   Curvature_Gauge_G2H2[3][1][5][0] = 0;
-  Curvature_Gauge_G2H2[3][1][5][1] = C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][5][1] = SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][5][2] = 0;
   Curvature_Gauge_G2H2[3][1][5][3] = 0;
   Curvature_Gauge_G2H2[3][1][5][4] = 0;
@@ -2720,7 +2730,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][5][8] = 0;
   Curvature_Gauge_G2H2[3][1][6][0] = 0;
   Curvature_Gauge_G2H2[3][1][6][1] = 0;
-  Curvature_Gauge_G2H2[3][1][6][2] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][6][2] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][6][3] = 0;
   Curvature_Gauge_G2H2[3][1][6][4] = 0;
   Curvature_Gauge_G2H2[3][1][6][5] = 0;
@@ -2730,7 +2741,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][7][0] = 0;
   Curvature_Gauge_G2H2[3][1][7][1] = 0;
   Curvature_Gauge_G2H2[3][1][7][2] = 0;
-  Curvature_Gauge_G2H2[3][1][7][3] = -C_gs * C_g / 0.2e1;
+  Curvature_Gauge_G2H2[3][1][7][3] =
+      -SMConstants.C_gs * SMConstants.C_g / 0.2e1;
   Curvature_Gauge_G2H2[3][1][7][4] = 0;
   Curvature_Gauge_G2H2[3][1][7][5] = 0;
   Curvature_Gauge_G2H2[3][1][7][6] = 0;
@@ -2745,7 +2757,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][1][8][6] = 0;
   Curvature_Gauge_G2H2[3][1][8][7] = 0;
   Curvature_Gauge_G2H2[3][1][8][8] = 0;
-  Curvature_Gauge_G2H2[3][2][0][0] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][0][0] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][0][1] = 0;
   Curvature_Gauge_G2H2[3][2][0][2] = 0;
   Curvature_Gauge_G2H2[3][2][0][3] = 0;
@@ -2755,7 +2767,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][0][7] = 0;
   Curvature_Gauge_G2H2[3][2][0][8] = 0;
   Curvature_Gauge_G2H2[3][2][1][0] = 0;
-  Curvature_Gauge_G2H2[3][2][1][1] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][1][1] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][1][2] = 0;
   Curvature_Gauge_G2H2[3][2][1][3] = 0;
   Curvature_Gauge_G2H2[3][2][1][4] = 0;
@@ -2765,7 +2777,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][1][8] = 0;
   Curvature_Gauge_G2H2[3][2][2][0] = 0;
   Curvature_Gauge_G2H2[3][2][2][1] = 0;
-  Curvature_Gauge_G2H2[3][2][2][2] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][2][2] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][2][3] = 0;
   Curvature_Gauge_G2H2[3][2][2][4] = 0;
   Curvature_Gauge_G2H2[3][2][2][5] = 0;
@@ -2775,7 +2787,7 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][3][0] = 0;
   Curvature_Gauge_G2H2[3][2][3][1] = 0;
   Curvature_Gauge_G2H2[3][2][3][2] = 0;
-  Curvature_Gauge_G2H2[3][2][3][3] = C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][3][3] = SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][3][4] = 0;
   Curvature_Gauge_G2H2[3][2][3][5] = 0;
   Curvature_Gauge_G2H2[3][2][3][6] = 0;
@@ -2785,7 +2797,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][4][1] = 0;
   Curvature_Gauge_G2H2[3][2][4][2] = 0;
   Curvature_Gauge_G2H2[3][2][4][3] = 0;
-  Curvature_Gauge_G2H2[3][2][4][4] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][4][4] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][4][5] = 0;
   Curvature_Gauge_G2H2[3][2][4][6] = 0;
   Curvature_Gauge_G2H2[3][2][4][7] = 0;
@@ -2795,7 +2808,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][5][2] = 0;
   Curvature_Gauge_G2H2[3][2][5][3] = 0;
   Curvature_Gauge_G2H2[3][2][5][4] = 0;
-  Curvature_Gauge_G2H2[3][2][5][5] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][5][5] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][5][6] = 0;
   Curvature_Gauge_G2H2[3][2][5][7] = 0;
   Curvature_Gauge_G2H2[3][2][5][8] = 0;
@@ -2805,7 +2819,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][6][3] = 0;
   Curvature_Gauge_G2H2[3][2][6][4] = 0;
   Curvature_Gauge_G2H2[3][2][6][5] = 0;
-  Curvature_Gauge_G2H2[3][2][6][6] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][6][6] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][6][7] = 0;
   Curvature_Gauge_G2H2[3][2][6][8] = 0;
   Curvature_Gauge_G2H2[3][2][7][0] = 0;
@@ -2815,7 +2830,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][7][4] = 0;
   Curvature_Gauge_G2H2[3][2][7][5] = 0;
   Curvature_Gauge_G2H2[3][2][7][6] = 0;
-  Curvature_Gauge_G2H2[3][2][7][7] = -C_g * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][2][7][7] =
+      -SMConstants.C_g * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][2][7][8] = 0;
   Curvature_Gauge_G2H2[3][2][8][0] = 0;
   Curvature_Gauge_G2H2[3][2][8][1] = 0;
@@ -2826,7 +2842,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][2][8][6] = 0;
   Curvature_Gauge_G2H2[3][2][8][7] = 0;
   Curvature_Gauge_G2H2[3][2][8][8] = 0;
-  Curvature_Gauge_G2H2[3][3][0][0] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][0][0] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][0][1] = 0;
   Curvature_Gauge_G2H2[3][3][0][2] = 0;
   Curvature_Gauge_G2H2[3][3][0][3] = 0;
@@ -2836,7 +2853,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][0][7] = 0;
   Curvature_Gauge_G2H2[3][3][0][8] = 0;
   Curvature_Gauge_G2H2[3][3][1][0] = 0;
-  Curvature_Gauge_G2H2[3][3][1][1] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][1][1] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][1][2] = 0;
   Curvature_Gauge_G2H2[3][3][1][3] = 0;
   Curvature_Gauge_G2H2[3][3][1][4] = 0;
@@ -2846,7 +2864,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][1][8] = 0;
   Curvature_Gauge_G2H2[3][3][2][0] = 0;
   Curvature_Gauge_G2H2[3][3][2][1] = 0;
-  Curvature_Gauge_G2H2[3][3][2][2] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][2][2] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][2][3] = 0;
   Curvature_Gauge_G2H2[3][3][2][4] = 0;
   Curvature_Gauge_G2H2[3][3][2][5] = 0;
@@ -2856,7 +2875,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][3][0] = 0;
   Curvature_Gauge_G2H2[3][3][3][1] = 0;
   Curvature_Gauge_G2H2[3][3][3][2] = 0;
-  Curvature_Gauge_G2H2[3][3][3][3] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][3][3] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][3][4] = 0;
   Curvature_Gauge_G2H2[3][3][3][5] = 0;
   Curvature_Gauge_G2H2[3][3][3][6] = 0;
@@ -2866,7 +2886,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][4][1] = 0;
   Curvature_Gauge_G2H2[3][3][4][2] = 0;
   Curvature_Gauge_G2H2[3][3][4][3] = 0;
-  Curvature_Gauge_G2H2[3][3][4][4] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][4][4] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][4][5] = 0;
   Curvature_Gauge_G2H2[3][3][4][6] = 0;
   Curvature_Gauge_G2H2[3][3][4][7] = 0;
@@ -2876,7 +2897,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][5][2] = 0;
   Curvature_Gauge_G2H2[3][3][5][3] = 0;
   Curvature_Gauge_G2H2[3][3][5][4] = 0;
-  Curvature_Gauge_G2H2[3][3][5][5] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][5][5] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][5][6] = 0;
   Curvature_Gauge_G2H2[3][3][5][7] = 0;
   Curvature_Gauge_G2H2[3][3][5][8] = 0;
@@ -2886,7 +2908,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][6][3] = 0;
   Curvature_Gauge_G2H2[3][3][6][4] = 0;
   Curvature_Gauge_G2H2[3][3][6][5] = 0;
-  Curvature_Gauge_G2H2[3][3][6][6] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][6][6] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][6][7] = 0;
   Curvature_Gauge_G2H2[3][3][6][8] = 0;
   Curvature_Gauge_G2H2[3][3][7][0] = 0;
@@ -2896,7 +2919,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][7][4] = 0;
   Curvature_Gauge_G2H2[3][3][7][5] = 0;
   Curvature_Gauge_G2H2[3][3][7][6] = 0;
-  Curvature_Gauge_G2H2[3][3][7][7] = C_gs * C_gs / 0.2e1;
+  Curvature_Gauge_G2H2[3][3][7][7] =
+      SMConstants.C_gs * SMConstants.C_gs / 0.2e1;
   Curvature_Gauge_G2H2[3][3][7][8] = 0;
   Curvature_Gauge_G2H2[3][3][8][0] = 0;
   Curvature_Gauge_G2H2[3][3][8][1] = 0;
@@ -2909,15 +2933,15 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   Curvature_Gauge_G2H2[3][3][8][8] = 0;
 
   std::complex<double> V11, V12, V13, V21, V22, V23, V31, V32, V33;
-  V11 = C_Vud;
-  V12 = C_Vus;
-  V13 = C_Vub;
-  V21 = C_Vcd;
-  V22 = C_Vcs;
-  V23 = C_Vcb;
-  V31 = C_Vtd;
-  V32 = C_Vts;
-  V33 = C_Vtb;
+  V11 = SMConstants.C_Vud;
+  V12 = SMConstants.C_Vus;
+  V13 = SMConstants.C_Vub;
+  V21 = SMConstants.C_Vcd;
+  V22 = SMConstants.C_Vcs;
+  V23 = SMConstants.C_Vcb;
+  V31 = SMConstants.C_Vtd;
+  V32 = SMConstants.C_Vts;
+  V33 = SMConstants.C_Vtb;
 
   MatrixXcd YIJR2(NQuarks, NQuarks), YIJE2(NQuarks, NQuarks),
       YIJS2(NQuarks, NQuarks), YIJP2(NQuarks, NQuarks), YIJRD(NQuarks, NQuarks),
@@ -2937,8 +2961,8 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   YIJSL = MatrixXcd::Zero(NLepton, NLepton);
   YIJPL = MatrixXcd::Zero(NLepton, NLepton);
 
-  double v1 = C_vev0 * C_CosBeta;
-  double v2 = C_vev0 * C_SinBeta;
+  double v1 = SMConstants.C_vev0 * C_CosBeta;
+  double v2 = SMConstants.C_vev0 * C_SinBeta;
   double vL = v2;
   double vD = v2;
   if (Type == 2)
@@ -2951,45 +2975,45 @@ void Class_Potential_RN2HDM::SetCurvatureArrays()
   else if (Type == 4)
     vD = v1;
 
-  YIJR2(0, 9)  = -std::conj(V11) * C_MassUp / v2;
-  YIJR2(0, 10) = -std::conj(V12) * C_MassUp / v2;
-  YIJR2(0, 11) = -std::conj(V13) * C_MassUp / v2;
+  YIJR2(0, 9)  = -std::conj(V11) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 10) = -std::conj(V12) * SMConstants.C_MassUp / v2;
+  YIJR2(0, 11) = -std::conj(V13) * SMConstants.C_MassUp / v2;
 
-  YIJR2(1, 9)  = -std::conj(V21) * C_MassCharm / v2;
-  YIJR2(1, 10) = -std::conj(V22) * C_MassCharm / v2;
-  YIJR2(1, 11) = -std::conj(V23) * C_MassCharm / v2;
+  YIJR2(1, 9)  = -std::conj(V21) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 10) = -std::conj(V22) * SMConstants.C_MassCharm / v2;
+  YIJR2(1, 11) = -std::conj(V23) * SMConstants.C_MassCharm / v2;
 
-  YIJR2(2, 9)  = -std::conj(V31) * C_MassTop / v2;
-  YIJR2(2, 10) = -std::conj(V32) * C_MassTop / v2;
-  YIJR2(2, 11) = -std::conj(V33) * C_MassTop / v2;
+  YIJR2(2, 9)  = -std::conj(V31) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 10) = -std::conj(V32) * SMConstants.C_MassTop / v2;
+  YIJR2(2, 11) = -std::conj(V33) * SMConstants.C_MassTop / v2;
 
-  YIJS2(0, 6) = C_MassUp / v2;
-  YIJS2(1, 7) = C_MassCharm / v2;
-  YIJS2(2, 8) = C_MassTop / v2;
+  YIJS2(0, 6) = SMConstants.C_MassUp / v2;
+  YIJS2(1, 7) = SMConstants.C_MassCharm / v2;
+  YIJS2(2, 8) = SMConstants.C_MassTop / v2;
 
-  YIJSD(3, 9)  = C_MassDown / vD;
-  YIJSD(4, 10) = C_MassStrange / vD;
-  YIJSD(5, 11) = C_MassBottom / vD;
+  YIJSD(3, 9)  = SMConstants.C_MassDown / vD;
+  YIJSD(4, 10) = SMConstants.C_MassStrange / vD;
+  YIJSD(5, 11) = SMConstants.C_MassBottom / vD;
 
-  YIJRD(3, 6) = V11 * C_MassDown / vD;
-  YIJRD(3, 7) = V21 * C_MassDown / vD;
-  YIJRD(3, 8) = V31 * C_MassDown / vD;
+  YIJRD(3, 6) = V11 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 7) = V21 * SMConstants.C_MassDown / vD;
+  YIJRD(3, 8) = V31 * SMConstants.C_MassDown / vD;
 
-  YIJRD(4, 6) = V12 * C_MassStrange / vD;
-  YIJRD(4, 7) = V22 * C_MassStrange / vD;
-  YIJRD(4, 8) = V32 * C_MassStrange / vD;
+  YIJRD(4, 6) = V12 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 7) = V22 * SMConstants.C_MassStrange / vD;
+  YIJRD(4, 8) = V32 * SMConstants.C_MassStrange / vD;
 
-  YIJRD(5, 6) = V13 * C_MassBottom / vD;
-  YIJRD(5, 7) = V23 * C_MassBottom / vD;
-  YIJRD(5, 8) = V33 * C_MassBottom / vD;
+  YIJRD(5, 6) = V13 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 7) = V23 * SMConstants.C_MassBottom / vD;
+  YIJRD(5, 8) = V33 * SMConstants.C_MassBottom / vD;
 
-  YIJRL(1, 6) = C_MassElectron / vL;
-  YIJRL(3, 7) = C_MassMu / vL;
-  YIJRL(5, 8) = C_MassTau / vL;
+  YIJRL(1, 6) = SMConstants.C_MassElectron / vL;
+  YIJRL(3, 7) = SMConstants.C_MassMu / vL;
+  YIJRL(5, 8) = SMConstants.C_MassTau / vL;
 
-  YIJSL(0, 1) = C_MassElectron / vL;
-  YIJSL(2, 3) = C_MassMu / vL;
-  YIJSL(4, 5) = C_MassTau / vL;
+  YIJSL(0, 1) = SMConstants.C_MassElectron / vL;
+  YIJSL(2, 3) = SMConstants.C_MassMu / vL;
+  YIJSL(4, 5) = SMConstants.C_MassTau / vL;
 
   for (std::size_t i = 0; i < NQuarks; i++)
   {
@@ -3089,17 +3113,24 @@ bool Class_Potential_RN2HDM::CalculateDebyeSimplified()
 
   if (Type == 1 or Type == 3) // Type I 2HDM oder Lepton Specific
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_SinBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_SinBeta);
   }
   if (Type == 2 or Type == 4) // Type II 2HDM oder Flipped
   {
-    cb = std::sqrt(2) * C_MassBottom / (C_vev0 * C_CosBeta);
+    cb = std::sqrt(2) * SMConstants.C_MassBottom /
+         (SMConstants.C_vev0 * C_CosBeta);
   }
   CTempC1 = 1.0 / 48 *
-            (12 * L1 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs));
-  double ct = std::sqrt(2) * C_MassTop / (C_vev0 * C_SinBeta);
-  CTempC2   = 1.0 / 48 *
-            (12 * L2 + 8 * L3 + 4 * L4 + 3 * (3 * C_g * C_g + C_gs * C_gs) +
+            (12 * L1 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs));
+  double ct =
+      std::sqrt(2) * SMConstants.C_MassTop / (SMConstants.C_vev0 * C_SinBeta);
+  CTempC2 = 1.0 / 48 *
+            (12 * L2 + 8 * L3 + 4 * L4 +
+             3 * (3 * SMConstants.C_g * SMConstants.C_g +
+                  SMConstants.C_gs * SMConstants.C_gs) +
              12 * ct * ct);
 
   if (Type == 1 or Type == 3)
@@ -3130,10 +3161,10 @@ bool Class_Potential_RN2HDM::CalculateDebyeSimplified()
 
 bool Class_Potential_RN2HDM::CalculateDebyeGaugeSimplified()
 {
-  DebyeGauge[0][0] = 2 * C_g * C_g;
-  DebyeGauge[1][1] = 2 * C_g * C_g;
-  DebyeGauge[2][2] = 2 * C_g * C_g;
-  DebyeGauge[3][3] = 2 * C_gs * C_gs;
+  DebyeGauge[0][0] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[1][1] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[2][2] = 2 * SMConstants.C_g * SMConstants.C_g;
+  DebyeGauge[3][3] = 2 * SMConstants.C_gs * SMConstants.C_gs;
 
   return true;
 }

--- a/src/models/ClassPotentialRN2HDM.cpp
+++ b/src/models/ClassPotentialRN2HDM.cpp
@@ -20,7 +20,8 @@ namespace BSMPT
 namespace Models
 {
 
-Class_Potential_RN2HDM::Class_Potential_RN2HDM()
+Class_Potential_RN2HDM::Class_Potential_RN2HDM(const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   // TODO Auto-generated constructor stub
   Model         = ModelID::ModelIDs::RN2HDM;

--- a/src/models/ClassTemplate.cpp
+++ b/src/models/ClassTemplate.cpp
@@ -33,7 +33,8 @@ namespace Models
  * Lagrangian parameters AFTER using the tadpole conditions), nParCT (number of
  * counterterms) as well as nVEV (number of VEVs for minimization)
  */
-Class_Template::Class_Template()
+Class_Template::Class_Template(const ISMConstants &smConstants)
+    : Class_Potential_Origin(smConstants)
 {
   Model =
       ModelID::ModelIDs::TEMPLATE; // global int constant which will be used to

--- a/src/models/ClassTemplate.cpp
+++ b/src/models/ClassTemplate.cpp
@@ -179,14 +179,15 @@ void Class_Template::set_gen(const std::vector<double> &par)
 {
   ms     = par[0]; // Class member is set accordingly to the input parameters
   lambda = par[1]; // Class member is set accordingly to the input parameters
-  g      = C_g;    // SM SU (2) gauge coupling --> SMparam .h
-  yt = std::sqrt(2) / C_vev0 * C_MassTop; // Top Yukawa coupling --> SMparam .h
-  scale = C_vev0; // Renormalisation scale is set to the SM VEV
+  g      = SMConstants.C_g; // SM SU (2) gauge coupling --> SMparam .h
+  yt     = std::sqrt(2) / SMConstants.C_vev0 *
+       SMConstants.C_MassTop; // Top Yukawa coupling --> SMparam .h
+  scale = SMConstants.C_vev0; // Renormalisation scale is set to the SM VEV
   vevTreeMin.resize(nVEV);
   vevTree.resize(NHiggs);
   // Here you have to set the vector vevTreeMin. The vector vevTree will then be
   // set by the function MinimizeOrderVEV
-  vevTreeMin[0] = C_vev0;
+  vevTreeMin[0] = SMConstants.C_vev0;
   vevTree       = MinimizeOrderVEV(vevTreeMin);
   if (!SetCurvatureDone) SetCurvatureArrays();
 }
@@ -266,12 +267,13 @@ std::vector<double> Class_Template::calc_CT() const
   // Here you have to use your formulae for the counterterm scheme
   double t = 0;
   parCT.push_back(t); // dT
-  parCT.push_back(3.0 * t / std::pow(C_vev0, 3) +
-                  3.0 / std::pow(C_vev0, 3) * NablaWeinberg(0) -
-                  3.0 / std::pow(C_vev0, 2) * HesseWeinberg(0, 0)); // dlambda
-  parCT.push_back(-3.0 / (2 * C_vev0) * NablaWeinberg(0) +
+  parCT.push_back(3.0 * t / std::pow(SMConstants.C_vev0, 3) +
+                  3.0 / std::pow(SMConstants.C_vev0, 3) * NablaWeinberg(0) -
+                  3.0 / std::pow(SMConstants.C_vev0, 2) *
+                      HesseWeinberg(0, 0)); // dlambda
+  parCT.push_back(-3.0 / (2 * SMConstants.C_vev0) * NablaWeinberg(0) +
                   1.0 / 2.0 * HesseWeinberg(0, 0) -
-                  3.0 * t / (2 * C_vev0)); // dms
+                  3.0 * t / (2 * SMConstants.C_vev0)); // dms
 
   return parCT;
 }

--- a/src/models/IncludeAllModels.cpp
+++ b/src/models/IncludeAllModels.cpp
@@ -24,21 +24,28 @@ namespace BSMPT
 namespace ModelID
 {
 
-std::unique_ptr<Class_Potential_Origin> FChoose(ModelIDs choice)
+std::unique_ptr<Class_Potential_Origin> FChoose(ModelIDs choice,
+                                                const ISMConstants &smConstants)
 {
   using namespace Models;
   switch (choice)
   {
-  case ModelIDs::R2HDM: return std::make_unique<Class_Potential_R2HDM>(); break;
-  case ModelIDs::C2HDM: return std::make_unique<Class_Potential_C2HDM>(); break;
+  case ModelIDs::R2HDM:
+    return std::make_unique<Class_Potential_R2HDM>(smConstants);
+    break;
+  case ModelIDs::C2HDM:
+    return std::make_unique<Class_Potential_C2HDM>(smConstants);
+    break;
   case ModelIDs::RN2HDM:
-    return std::make_unique<Class_Potential_RN2HDM>();
+    return std::make_unique<Class_Potential_RN2HDM>(smConstants);
     break;
-  case ModelIDs::CXSM: return std::make_unique<Class_CxSM>(); break;
+  case ModelIDs::CXSM: return std::make_unique<Class_CxSM>(smConstants); break;
   case ModelIDs::CPINTHEDARK:
-    return std::make_unique<Class_Potential_CPintheDark>();
+    return std::make_unique<Class_Potential_CPintheDark>(smConstants);
     break;
-  case ModelIDs::TEMPLATE: return std::make_unique<Class_Template>(); break;
+  case ModelIDs::TEMPLATE:
+    return std::make_unique<Class_Template>(smConstants);
+    break;
   default: throw std::runtime_error("Invalid model");
   }
 }

--- a/src/models/ModelTestfunctions.cpp
+++ b/src/models/ModelTestfunctions.cpp
@@ -443,6 +443,7 @@ TestResults CheckTreeLevelMin(const Class_Potential_Origin &point,
       Minimizer::Minimize_gen_all_tree_level(point.get_Model(),
                                              point.get_parStored(),
                                              point.get_parCTStored(),
+                                             point.SMConstants,
                                              CheckVector,
                                              start,
                                              WhichMinimizer);

--- a/src/models/ModelTestfunctions.cpp
+++ b/src/models/ModelTestfunctions.cpp
@@ -254,9 +254,9 @@ TestResults CheckGaugeBosonMasses(const Class_Potential_Origin &point)
 
   std::vector<double> gaugeMassesInput;
   gaugeMassesInput.push_back(0);
-  gaugeMassesInput.push_back(pow(C_MassW, 2));
-  gaugeMassesInput.push_back(pow(C_MassW, 2));
-  gaugeMassesInput.push_back(pow(C_MassZ, 2));
+  gaugeMassesInput.push_back(pow(point.SMConstants.C_MassW, 2));
+  gaugeMassesInput.push_back(pow(point.SMConstants.C_MassW, 2));
+  gaugeMassesInput.push_back(pow(point.SMConstants.C_MassZ, 2));
   std::sort(gaugeMassesInput.begin(), gaugeMassesInput.end());
   auto GaugeMassCalculated = point.GaugeMassesSquared(
       point.MinimizeOrderVEV(point.get_vevTreeMin()), 0, 0);
@@ -312,26 +312,26 @@ CheckFermionicMasses(const Class_Potential_Origin &point)
   leptonMassesInput.push_back(0);
   leptonMassesInput.push_back(0);
   leptonMassesInput.push_back(0);
-  leptonMassesInput.push_back(pow(C_MassElectron, 2));
-  leptonMassesInput.push_back(pow(-C_MassElectron, 2));
-  leptonMassesInput.push_back(pow(C_MassMu, 2));
-  leptonMassesInput.push_back(pow(-C_MassMu, 2));
-  leptonMassesInput.push_back(pow(C_MassTau, 2));
-  leptonMassesInput.push_back(pow(-C_MassTau, 2));
+  leptonMassesInput.push_back(pow(point.SMConstants.C_MassElectron, 2));
+  leptonMassesInput.push_back(pow(-point.SMConstants.C_MassElectron, 2));
+  leptonMassesInput.push_back(pow(point.SMConstants.C_MassMu, 2));
+  leptonMassesInput.push_back(pow(-point.SMConstants.C_MassMu, 2));
+  leptonMassesInput.push_back(pow(point.SMConstants.C_MassTau, 2));
+  leptonMassesInput.push_back(pow(-point.SMConstants.C_MassTau, 2));
 
-  quarkMassesInput.push_back(pow(C_MassUp, 2));
-  quarkMassesInput.push_back(pow(-C_MassUp, 2));
-  quarkMassesInput.push_back(pow(C_MassCharm, 2));
-  quarkMassesInput.push_back(pow(-C_MassCharm, 2));
-  quarkMassesInput.push_back(pow(C_MassTop, 2));
-  quarkMassesInput.push_back(pow(-C_MassTop, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassUp, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassUp, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassCharm, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassCharm, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassTop, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassTop, 2));
 
-  quarkMassesInput.push_back(pow(C_MassDown, 2));
-  quarkMassesInput.push_back(pow(-C_MassDown, 2));
-  quarkMassesInput.push_back(pow(C_MassStrange, 2));
-  quarkMassesInput.push_back(pow(-C_MassStrange, 2));
-  quarkMassesInput.push_back(pow(C_MassBottom, 2));
-  quarkMassesInput.push_back(pow(-C_MassBottom, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassDown, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassDown, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassStrange, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassStrange, 2));
+  quarkMassesInput.push_back(pow(point.SMConstants.C_MassBottom, 2));
+  quarkMassesInput.push_back(pow(-point.SMConstants.C_MassBottom, 2));
 
   if (point.get_NLepton() == 0)
   {
@@ -642,19 +642,19 @@ TestResults CheckVCounterSimplified(const Class_Potential_Origin &point)
   return result;
 }
 
-TestResults CheckCKMUnitarity()
+TestResults CheckCKMUnitarity(const ISMConstants SMConstants)
 {
   using namespace Eigen;
   MatrixXcd VCKM(3, 3);
-  VCKM(0, 0) = C_Vud;
-  VCKM(0, 1) = C_Vus;
-  VCKM(0, 2) = C_Vub;
-  VCKM(1, 0) = C_Vcd;
-  VCKM(1, 1) = C_Vcs;
-  VCKM(1, 2) = C_Vcb;
-  VCKM(2, 0) = C_Vtd;
-  VCKM(2, 1) = C_Vts;
-  VCKM(2, 2) = C_Vtb;
+  VCKM(0, 0) = SMConstants.C_Vud;
+  VCKM(0, 1) = SMConstants.C_Vus;
+  VCKM(0, 2) = SMConstants.C_Vub;
+  VCKM(1, 0) = SMConstants.C_Vcd;
+  VCKM(1, 1) = SMConstants.C_Vcs;
+  VCKM(1, 2) = SMConstants.C_Vcb;
+  VCKM(2, 0) = SMConstants.C_Vtd;
+  VCKM(2, 1) = SMConstants.C_Vts;
+  VCKM(2, 2) = SMConstants.C_Vtb;
 
   double ZeroMass = std::pow(10, -5);
   auto norm       = (VCKM.adjoint() * VCKM - MatrixXcd::Identity(3, 3)).norm();

--- a/src/models/ModelTestfunctions.cpp
+++ b/src/models/ModelTestfunctions.cpp
@@ -642,7 +642,7 @@ TestResults CheckVCounterSimplified(const Class_Potential_Origin &point)
   return result;
 }
 
-TestResults CheckCKMUnitarity(const ISMConstants SMConstants)
+TestResults CheckCKMUnitarity(const ISMConstants &SMConstants)
 {
   using namespace Eigen;
   MatrixXcd VCKM(3, 3);

--- a/src/models/SMParam.cpp
+++ b/src/models/SMParam.cpp
@@ -1,0 +1,63 @@
+#include <BSMPT/models/SMparam.h>
+
+namespace BSMPT
+{
+const ISMConstants GetSMConstants()
+{
+  ISMConstants SM;
+  SM.C_Wolfenstein_lambda = 0.22537;
+  SM.C_Wolfenstein_A      = 0.814;
+  SM.C_Wolfenstein_rho    = 0.117;
+  SM.C_Wolfenstein_eta    = 0.353;
+  SM.theta12              = std::asin(SM.C_Wolfenstein_lambda);
+  SM.theta23 =
+      std::asin(SM.C_Wolfenstein_A * std::pow(SM.C_Wolfenstein_lambda, 2));
+  SM.delta =
+      std::arg(SM.C_Wolfenstein_A * std::pow(SM.C_Wolfenstein_lambda, 3) *
+               (SM.C_Wolfenstein_rho + II * SM.C_Wolfenstein_eta));
+  SM.theta13 = std::asin(
+      std::abs(SM.C_Wolfenstein_A * std::pow(SM.C_Wolfenstein_lambda, 3) *
+               (SM.C_Wolfenstein_rho + II * SM.C_Wolfenstein_eta)));
+  SM.C_Vud = std::cos(SM.theta12) * std::cos(SM.theta13);
+  SM.C_Vus = std::sin(SM.theta12) * std::cos(SM.theta13);
+  SM.C_Vub = std::sin(SM.theta13) * std::exp(-SM.delta * II);
+  SM.C_Vcd = -std::sin(SM.theta12) * std::cos(SM.theta23) -
+             std::cos(SM.theta12) * std::sin(SM.theta23) *
+                 std::sin(SM.theta13) * std::exp(II * SM.delta);
+  SM.C_Vcs = std::cos(SM.theta12) * std::cos(SM.theta23) -
+             std::sin(SM.theta12) * std::sin(SM.theta23) *
+                 std::sin(SM.theta13) * std::exp(II * SM.delta);
+  SM.C_Vcb = std::sin(SM.theta23) * std::cos(SM.theta13);
+  SM.C_Vtd = std::sin(SM.theta12) * std::sin(SM.theta23) -
+             std::cos(SM.theta12) * std::cos(SM.theta23) *
+                 std::sin(SM.theta13) * std::exp(II * SM.delta);
+  SM.C_Vts = -std::cos(SM.theta12) * std::sin(SM.theta23) -
+             std::sin(SM.theta12) * std::cos(SM.theta23) *
+                 std::sin(SM.theta13) * std::exp(II * SM.delta);
+  SM.C_Vtb = std::cos(SM.theta23) * std::cos(SM.theta13);
+
+  SM.C_MassW        = 80.385;
+  SM.C_MassZ        = 91.1876;
+  SM.C_MassSMHiggs  = 125.09;
+  SM.C_MassUp       = 0.1;
+  SM.C_MassDown     = 0.1;
+  SM.C_MassStrange  = 0.1;
+  SM.C_MassTop      = 172.5;
+  SM.C_MassCharm    = 1.51;
+  SM.C_MassBottom   = 4.92;
+  SM.C_MassTau      = 1.77682;
+  SM.C_MassMu       = 0.1056583715;
+  SM.C_MassElectron = 0.510998928 * std::pow(10.0, -3.0);
+  SM.C_GF           = 1.1663787 * 1e-5;
+
+  SM.C_sinsquaredWeinberg =
+      1 - (SM.C_MassW * SM.C_MassW) / (SM.C_MassZ * SM.C_MassZ);
+  SM.C_vev0 = std::sqrt(1 / std::sqrt(2) * 1 / SM.C_GF);
+  SM.C_g    = 2 * SM.C_MassW / SM.C_vev0;
+  SM.C_gs   = 2 * std::sqrt(std::pow(SM.C_MassZ, 2) - std::pow(SM.C_MassW, 2)) /
+            SM.C_vev0;
+  SM.C_SMTriHiggs = 3 * SM.C_MassSMHiggs * SM.C_MassSMHiggs / (SM.C_vev0);
+
+  return SM;
+}
+} // namespace BSMPT

--- a/src/prog/BSMPT.cpp
+++ b/src/prog/BSMPT.cpp
@@ -55,6 +55,7 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
+  const auto SMConstants = GetSMConstants();
   /**
    * PrintErrorLines decides if parameter points with no valid EWPT (no NLO
    * stability or T=300 vanishing VEV) are printed in the output file
@@ -88,7 +89,7 @@ try
   }
   std::string linestr;
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
   while (getline(infile, linestr))
   {
     if (linecounter > args.LastLine) break;

--- a/src/prog/CalcCT.cpp
+++ b/src/prog/CalcCT.cpp
@@ -48,8 +48,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
 
@@ -75,7 +75,7 @@ try
   std::string linestr;
 
   std::unique_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
 
   while (getline(infile, linestr))
   {

--- a/src/prog/CalculateEWBG.cpp
+++ b/src/prog/CalculateEWBG.cpp
@@ -56,6 +56,8 @@ int main(int argc, char *argv[])
 try
 {
 
+  const auto SMConstants = GetSMConstants();
+
   auto argparser = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
@@ -66,7 +68,7 @@ try
   }
 
   // Init: Interface Class for the different transport methods
-  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile);
+  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile, SMConstants);
 
   int linecounter = 1;
   std::ifstream infile(args.InputFile);

--- a/src/prog/CalculateEWBG.cpp
+++ b/src/prog/CalculateEWBG.cpp
@@ -87,7 +87,8 @@ try
   }
   std::string linestr;
   std::shared_ptr<Class_Potential_Origin> modelPointer = ModelID::FChoose(
-      args.Model); // Declare the model pointer with the necessary parameters
+      args.Model,
+      SMConstants); // Declare the model pointer with the necessary parameters
   std::vector<std::string> etaLegend =
       EtaInterface.legend(); // Declare the vector for the PTFinder algorithm
                              // Begin: Input Read

--- a/src/prog/NLOVEV.cpp
+++ b/src/prog/NLOVEV.cpp
@@ -52,8 +52,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -78,7 +78,7 @@ try
   std::string linestr;
 
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
   std::vector<double> Check;
   while (true)
   {

--- a/src/prog/PlotEWBG_nL.cpp
+++ b/src/prog/PlotEWBG_nL.cpp
@@ -53,7 +53,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -62,7 +63,7 @@ try
   }
 
   // Set up of BSMPT/Baryo Classes
-  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile);
+  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile, SMConstants);
   std::shared_ptr<Class_Potential_Origin> modelPointer =
       ModelID::FChoose(args.Model);
 
@@ -170,7 +171,7 @@ try
                     "Starting setting the class instances",
                     __FILE__,
                     __LINE__);
-    BSMPT::Baryo::tau_source C_tau;
+    BSMPT::Baryo::tau_source C_tau(SMConstants);
     EtaInterface.set_transport_method(
         TransportMethod::tau); // setting to tau class
     bool botflag     = true;

--- a/src/prog/PlotEWBG_nL.cpp
+++ b/src/prog/PlotEWBG_nL.cpp
@@ -65,7 +65,7 @@ try
   // Set up of BSMPT/Baryo Classes
   Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile, SMConstants);
   std::shared_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
 
   std::vector<double> start, solPot;
 

--- a/src/prog/PlotEWBG_vw.cpp
+++ b/src/prog/PlotEWBG_vw.cpp
@@ -51,7 +51,8 @@ int main(int argc, char *argv[])
 try
 {
 
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -60,7 +61,7 @@ try
   }
 
   // Set up of BSMPT/Baryo Classes
-  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile);
+  Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile, SMConstants);
   std::shared_ptr<Class_Potential_Origin> modelPointer =
       ModelID::FChoose(args.Model);
 

--- a/src/prog/PlotEWBG_vw.cpp
+++ b/src/prog/PlotEWBG_vw.cpp
@@ -63,7 +63,7 @@ try
   // Set up of BSMPT/Baryo Classes
   Baryo::CalculateEtaInterface EtaInterface(args.ConfigFile, SMConstants);
   std::shared_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
 
   std::ifstream infile(args.InputFile);
   if (!infile.good())

--- a/src/prog/Test.cpp
+++ b/src/prog/Test.cpp
@@ -52,8 +52,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -73,7 +73,7 @@ try
 
   std::string linestr;
   std::unique_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
 
   Logger::Write(LoggingLevel::ProgDetailed, "Created modelpointer ");
 

--- a/src/prog/TripleHiggsNLO.cpp
+++ b/src/prog/TripleHiggsNLO.cpp
@@ -44,8 +44,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -70,7 +70,7 @@ try
   std::string linestr;
 
   std::unique_ptr<Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
   std::size_t nPar, nParCT;
   nPar   = modelPointer->get_nPar();
   nParCT = modelPointer->get_nParCT();

--- a/src/prog/VEVEVO.cpp
+++ b/src/prog/VEVEVO.cpp
@@ -51,7 +51,8 @@ std::vector<std::string> convert_input(int argc, char *argv[]);
 int main(int argc, char *argv[])
 try
 {
-  auto argparser = prepare_parser();
+  const auto SMConstants = GetSMConstants();
+  auto argparser         = prepare_parser();
   argparser.add_input(convert_input(argc, argv));
   const CLIOptions args(argparser);
   if (not args.good())
@@ -62,7 +63,7 @@ try
   std::vector<double> sol, start, solPot;
 
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(args.Model);
+      ModelID::FChoose(args.Model, SMConstants);
   std::ifstream infile(args.InputFile);
   if (!infile.good())
   {

--- a/tests/benchmarks/benchmark-ewbg-c2hdm.cpp
+++ b/tests/benchmarks/benchmark-ewbg-c2hdm.cpp
@@ -45,7 +45,7 @@ static void BM_EWBG(benchmark::State &state)
   using namespace BSMPT;
   const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   const auto WhichMin = Minimizer::WhichMinimizerDefault;

--- a/tests/benchmarks/benchmark-ewbg-c2hdm.cpp
+++ b/tests/benchmarks/benchmark-ewbg-c2hdm.cpp
@@ -40,40 +40,40 @@ void CompareValues(T expected, T result, double epsilon, double threshold)
 }
 } // namespace
 
-
-static void BM_EWBG(benchmark::State& state)
+static void BM_EWBG(benchmark::State &state)
 {
-    using namespace BSMPT;
-    std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-        ModelID::FChoose(ModelID::ModelIDs::C2HDM);
-    modelPointer->initModel(example_point_C2HDM);
+  using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+  modelPointer->initModel(example_point_C2HDM);
 
-    const auto WhichMin = Minimizer::WhichMinimizerDefault;
+  const auto WhichMin = Minimizer::WhichMinimizerDefault;
 
-    const auto EWPT = Expected.EWPTPerSetting.at(WhichMin);
+  const auto EWPT = Expected.EWPTPerSetting.at(WhichMin);
 
-    std::vector<double> vevsymmetricSolution, checksym, startpoint;
-    for (const auto &el : EWPT.EWMinimum)
-      startpoint.push_back(0.5 * el);
-    vevsymmetricSolution = Minimizer::Minimize_gen_all(
-        modelPointer, EWPT.Tc + 1, checksym, startpoint, WhichMin, true);
-    auto min_expected = Expected.vevSymmetricPerSetting.at(WhichMin);
+  std::vector<double> vevsymmetricSolution, checksym, startpoint;
+  for (const auto &el : EWPT.EWMinimum)
+    startpoint.push_back(0.5 * el);
+  vevsymmetricSolution = Minimizer::Minimize_gen_all(
+      modelPointer, EWPT.Tc + 1, checksym, startpoint, WhichMin, true);
+  auto min_expected = Expected.vevSymmetricPerSetting.at(WhichMin);
 
-    auto config =
-        std::pair<std::vector<bool>, int>{std::vector<bool>(5, true), 1};
-    const double testVW = Expected.testVW;
+  auto config =
+      std::pair<std::vector<bool>, int>{std::vector<bool>(5, true), 1};
+  const double testVW = Expected.testVW;
 
-    for(auto _ : state)
-    {
-        Baryo::CalculateEtaInterface benchmarkEtaInterface(config);
-        auto result = benchmarkEtaInterface.CalcEta(testVW,
-                                             EWPT.EWMinimum,
-                                             vevsymmetricSolution,
-                                             EWPT.Tc,
-                                             modelPointer,
-                                             WhichMin);
-        (void)result;
-    }
+  for (auto _ : state)
+  {
+    Baryo::CalculateEtaInterface benchmarkEtaInterface(config, SMConstants);
+    auto result = benchmarkEtaInterface.CalcEta(testVW,
+                                                EWPT.EWMinimum,
+                                                vevsymmetricSolution,
+                                                EWPT.Tc,
+                                                modelPointer,
+                                                WhichMin);
+    (void)result;
+  }
 }
 
 BENCHMARK(BM_EWBG)->Repetitions(5);

--- a/tests/benchmarks/benchmark-ewpt-c2hdm.cpp
+++ b/tests/benchmarks/benchmark-ewpt-c2hdm.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-
 #include <benchmark/benchmark.h>
 
 #include <BSMPT/minimizer/Minimizer.h>
@@ -26,43 +25,41 @@ const std::vector<double> example_point_C2HDM{/* lambda_1 = */ 3.29771,
                                               /* Yukawa Type = */ 1};
 }
 
-static void BM_NLOVEV(benchmark::State& state)
+static void BM_NLOVEV(benchmark::State &state)
 {
-    using namespace BSMPT;
-    std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-        ModelID::FChoose(ModelID::ModelIDs::C2HDM);
-    modelPointer->initModel(example_point_C2HDM);
-    for(auto _ : state)
-    {
-        std::vector<double> Check;
-        auto result = Minimizer::Minimize_gen_all(modelPointer,
-                                           0,
-                                           Check,
-                                           modelPointer->get_vevTreeMin(),
-                                           Minimizer::WhichMinimizerDefault);
-        (void)result;
-    }
+  using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
+  modelPointer->initModel(example_point_C2HDM);
+  for (auto _ : state)
+  {
+    std::vector<double> Check;
+    auto result = Minimizer::Minimize_gen_all(modelPointer,
+                                              0,
+                                              Check,
+                                              modelPointer->get_vevTreeMin(),
+                                              Minimizer::WhichMinimizerDefault);
+    (void)result;
+  }
 }
 
-
-static void BM_EWPT(benchmark::State& state)
+static void BM_EWPT(benchmark::State &state)
 {
-    using namespace BSMPT;
-    std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-        ModelID::FChoose(ModelID::ModelIDs::C2HDM);
-    modelPointer->initModel(example_point_C2HDM);
-    for(auto _ : state)
-    {
-        std::vector<double> Check;
-        auto result = Minimizer::PTFinder_gen_all(
-            modelPointer, 0, 300, Minimizer::WhichMinimizerDefault);
-        (void)result;
-    }
+  using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
+  modelPointer->initModel(example_point_C2HDM);
+  for (auto _ : state)
+  {
+    std::vector<double> Check;
+    auto result = Minimizer::PTFinder_gen_all(
+        modelPointer, 0, 300, Minimizer::WhichMinimizerDefault);
+    (void)result;
+  }
 }
-
 
 BENCHMARK(BM_NLOVEV);
 BENCHMARK(BM_EWPT)->Repetitions(5);
 BENCHMARK_MAIN();
-
-

--- a/tests/unittests/Test-c2hdm.cpp
+++ b/tests/unittests/Test-c2hdm.cpp
@@ -31,8 +31,9 @@ using Approx = Catch::Approx;
 TEST_CASE("Checking NLOVEV for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   std::vector<double> Check;
   auto sol = Minimizer::Minimize_gen_all(modelPointer,
@@ -51,8 +52,9 @@ TEST_CASE("Checking NLOVEV for C2HDM", "[c2hdm]")
 TEST_CASE("Checking EWPT for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   std::vector<double> Check;
   auto EWPT = Minimizer::PTFinder_gen_all(
@@ -90,8 +92,9 @@ TEST_CASE("Checking EWPT for C2HDM", "[c2hdm]")
 TEST_CASE("Checking number of CT parameters for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckNumberOfCTParameters(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -100,8 +103,9 @@ TEST_CASE("Checking number of CT parameters for C2HDM", "[c2hdm]")
 TEST_CASE("Checking number of VEV labels for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckNumberOfVEVLabels(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -112,8 +116,9 @@ TEST_CASE(
     "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckLegendTemp(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -122,8 +127,9 @@ TEST_CASE(
 TEST_CASE("Checking number of triple Higgs couplings for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckNumberOfTripleCouplings(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -132,8 +138,9 @@ TEST_CASE("Checking number of triple Higgs couplings for C2HDM", "[c2hdm]")
 TEST_CASE("Checking Gauge Boson masses for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckGaugeBosonMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -142,8 +149,9 @@ TEST_CASE("Checking Gauge Boson masses for C2HDM", "[c2hdm]")
 TEST_CASE("Checking fermion and quark masses masses for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckFermionicMasses(*modelPointer);
   REQUIRE(result.first == ModelTests::TestResults::Pass);
@@ -153,8 +161,9 @@ TEST_CASE("Checking fermion and quark masses masses for C2HDM", "[c2hdm]")
 TEST_CASE("Checking tree level minimum for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckTreeLevelMin(*modelPointer,
                                               Minimizer::WhichMinimizerDefault);
@@ -164,8 +173,9 @@ TEST_CASE("Checking tree level minimum for C2HDM", "[c2hdm]")
 TEST_CASE("Checking tree level tadpoles for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckTadpoleRelations(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -174,8 +184,9 @@ TEST_CASE("Checking tree level tadpoles for C2HDM", "[c2hdm]")
 TEST_CASE("Checking NLO masses matching tree level masses for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckNLOMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -184,8 +195,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for C2HDM", "[c2hdm]")
 TEST_CASE("Checking VTreeSimplified for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   if (modelPointer->UseVTreeSimplified)
   {
     modelPointer->initModel(example_point_C2HDM);
@@ -201,8 +213,9 @@ TEST_CASE("Checking VTreeSimplified for C2HDM", "[c2hdm]")
 TEST_CASE("Checking VCounterSimplified for C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   if (modelPointer->UseVCounterSimplified)
   {
     modelPointer->initModel(example_point_C2HDM);
@@ -219,8 +232,9 @@ TEST_CASE("Checking first derivative of the sum of CT and CW in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckCTConditionsFirstDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -230,8 +244,9 @@ TEST_CASE("Checking second derivative of the sum of CT and CW in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckCTConditionsSecondDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -241,8 +256,9 @@ TEST_CASE("Checking the identities required to vanish for the CT in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   auto result = ModelTests::CheckCTIdentities(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -252,13 +268,15 @@ TEST_CASE("Checking triple higgs NLO couplings in the C2HDM", "[c2hdm]")
 {
 
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   modelPointer->Prepare_Triple();
   modelPointer->TripleHiggsCouplings();
 
-  auto Check = [](auto result, auto expected) {
+  auto Check = [](auto result, auto expected)
+  {
     if (std::abs(expected) > 1e-4)
     {
       REQUIRE(result == Approx(expected).epsilon(1e-4));
@@ -305,8 +323,9 @@ TEST_CASE("Checking triple higgs NLO couplings in the C2HDM", "[c2hdm]")
 TEST_CASE("Check number of calculated CT parameters in the C2HDM", "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   REQUIRE(ModelTests::TestResults::Pass ==
           ModelTests::CheckCTNumber(*modelPointer));
@@ -316,8 +335,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lij in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -329,8 +349,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijk in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -342,8 +363,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijkl in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -355,8 +377,9 @@ TEST_CASE("Check symmetric properties of the gauge tensor in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -368,8 +391,9 @@ TEST_CASE("Check symmetric properties of the Lepton tensor in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -381,8 +405,9 @@ TEST_CASE("Check symmetric properties of the mass Lepton tensor in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -394,8 +419,9 @@ TEST_CASE("Check symmetric properties of the mass quark tensor in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -407,8 +433,9 @@ TEST_CASE("Check symmetric properties of the quark tensor in the C2HDM",
           "[c2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==

--- a/tests/unittests/Test-cpinthedark.cpp
+++ b/tests/unittests/Test-cpinthedark.cpp
@@ -36,8 +36,9 @@ const Compare_CPINTHEDARK Expected;
 TEST_CASE("Checking NLOVEV for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   std::vector<double> Check;
   auto sol = Minimizer::Minimize_gen_all(modelPointer,
@@ -56,8 +57,9 @@ TEST_CASE("Checking NLOVEV for CPINTHEDARK", "[cpinthedark]")
 TEST_CASE("Checking EWPT for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   std::vector<double> Check;
   auto EWPT = Minimizer::PTFinder_gen_all(
@@ -95,8 +97,9 @@ TEST_CASE("Checking EWPT for CPINTHEDARK", "[cpinthedark]")
 TEST_CASE("Checking number of CT parameters for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckNumberOfCTParameters(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -105,8 +108,9 @@ TEST_CASE("Checking number of CT parameters for CPINTHEDARK", "[cpinthedark]")
 TEST_CASE("Checking number of VEV labels for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckNumberOfVEVLabels(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -117,8 +121,9 @@ TEST_CASE("Checking number of labels for temperature dependend results for "
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckLegendTemp(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -128,8 +133,9 @@ TEST_CASE("Checking number of triple Higgs couplings for CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckNumberOfTripleCouplings(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -138,8 +144,9 @@ TEST_CASE("Checking number of triple Higgs couplings for CPINTHEDARK",
 TEST_CASE("Checking Gauge Boson masses for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckGaugeBosonMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -149,8 +156,9 @@ TEST_CASE("Checking fermion and quark masses masses for CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckFermionicMasses(*modelPointer);
   REQUIRE(result.first == ModelTests::TestResults::Pass);
@@ -160,8 +168,9 @@ TEST_CASE("Checking fermion and quark masses masses for CPINTHEDARK",
 TEST_CASE("Checking tree level minimum for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckTreeLevelMin(*modelPointer,
                                               Minimizer::WhichMinimizerDefault);
@@ -171,8 +180,9 @@ TEST_CASE("Checking tree level minimum for CPINTHEDARK", "[cpinthedark]")
 TEST_CASE("Checking tree level tadpoles for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckTadpoleRelations(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -182,8 +192,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckNLOMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -192,8 +203,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for CPINTHEDARK",
 TEST_CASE("Checking VTreeSimplified for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   if (modelPointer->UseVTreeSimplified)
   {
     modelPointer->initModel(example_point_CPINTHEDARK);
@@ -209,8 +221,9 @@ TEST_CASE("Checking VTreeSimplified for CPINTHEDARK", "[cpinthedark]")
 TEST_CASE("Checking VCounterSimplified for CPINTHEDARK", "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   if (modelPointer->UseVCounterSimplified)
   {
     modelPointer->initModel(example_point_CPINTHEDARK);
@@ -228,8 +241,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckCTConditionsFirstDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -240,8 +254,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckCTConditionsSecondDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -252,8 +267,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   auto result = ModelTests::CheckCTIdentities(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -264,13 +280,15 @@ TEST_CASE("Checking triple higgs NLO couplings in the CPINTHEDARK",
 {
 
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   modelPointer->Prepare_Triple();
   modelPointer->TripleHiggsCouplings();
 
-  auto Check = [](auto result, auto expected) {
+  auto Check = [](auto result, auto expected)
+  {
     if (std::abs(expected) > 1e-4)
     {
       REQUIRE(result == Approx(expected).epsilon(1e-4));
@@ -318,8 +336,9 @@ TEST_CASE("Check number of calculated CT parameters in the CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
   REQUIRE(ModelTests::TestResults::Pass ==
           ModelTests::CheckCTNumber(*modelPointer));
@@ -330,8 +349,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -344,8 +364,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -358,8 +379,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -371,8 +393,9 @@ TEST_CASE("Check symmetric properties of the gauge tensor in the CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -384,8 +407,9 @@ TEST_CASE("Check symmetric properties of the Lepton tensor in the CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -398,8 +422,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -412,8 +437,9 @@ TEST_CASE(
     "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -425,8 +451,9 @@ TEST_CASE("Check symmetric properties of the quark tensor in the CPINTHEDARK",
           "[cpinthedark]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK);
+      ModelID::FChoose(ModelID::ModelIDs::CPINTHEDARK, SMConstants);
   modelPointer->initModel(example_point_CPINTHEDARK);
 
   REQUIRE(ModelTests::TestResults::Pass ==

--- a/tests/unittests/Test-cxsm.cpp
+++ b/tests/unittests/Test-cxsm.cpp
@@ -35,8 +35,9 @@ const Compare_CXSM Expected;
 TEST_CASE("Checking NLOVEV for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   std::vector<double> Check;
   auto sol = Minimizer::Minimize_gen_all(modelPointer,
@@ -59,8 +60,9 @@ TEST_CASE("Checking NLOVEV for CXSM", "[CXSM]")
 TEST_CASE("Checking EWPT for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   std::vector<double> Check;
   auto EWPT = Minimizer::PTFinder_gen_all(
@@ -98,8 +100,9 @@ TEST_CASE("Checking EWPT for CXSM", "[CXSM]")
 TEST_CASE("Checking number of CT parameters for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckNumberOfCTParameters(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -108,8 +111,9 @@ TEST_CASE("Checking number of CT parameters for CXSM", "[CXSM]")
 TEST_CASE("Checking number of VEV labels for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckNumberOfVEVLabels(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -120,8 +124,9 @@ TEST_CASE(
     "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckLegendTemp(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -130,8 +135,9 @@ TEST_CASE(
 TEST_CASE("Checking number of triple Higgs couplings for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckNumberOfTripleCouplings(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -140,8 +146,9 @@ TEST_CASE("Checking number of triple Higgs couplings for CXSM", "[CXSM]")
 TEST_CASE("Checking Gauge Boson masses for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckGaugeBosonMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -150,8 +157,9 @@ TEST_CASE("Checking Gauge Boson masses for CXSM", "[CXSM]")
 TEST_CASE("Checking fermion and quark masses masses for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckFermionicMasses(*modelPointer);
   REQUIRE(result.first == ModelTests::TestResults::Pass);
@@ -161,8 +169,9 @@ TEST_CASE("Checking fermion and quark masses masses for CXSM", "[CXSM]")
 TEST_CASE("Checking tree level minimum for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckTreeLevelMin(*modelPointer,
                                               Minimizer::WhichMinimizerDefault);
@@ -172,8 +181,9 @@ TEST_CASE("Checking tree level minimum for CXSM", "[CXSM]")
 TEST_CASE("Checking tree level tadpoles for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckTadpoleRelations(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -182,8 +192,9 @@ TEST_CASE("Checking tree level tadpoles for CXSM", "[CXSM]")
 TEST_CASE("Checking NLO masses matching tree level masses for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckNLOMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -192,8 +203,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for CXSM", "[CXSM]")
 TEST_CASE("Checking VTreeSimplified for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   if (modelPointer->UseVTreeSimplified)
   {
     modelPointer->initModel(example_point_CXSM);
@@ -209,8 +221,9 @@ TEST_CASE("Checking VTreeSimplified for CXSM", "[CXSM]")
 TEST_CASE("Checking VCounterSimplified for CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   if (modelPointer->UseVCounterSimplified)
   {
     modelPointer->initModel(example_point_CXSM);
@@ -227,8 +240,9 @@ TEST_CASE("Checking first derivative of the sum of CT and CW in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckCTConditionsFirstDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -238,8 +252,9 @@ TEST_CASE("Checking second derivative of the sum of CT and CW in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckCTConditionsSecondDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -249,8 +264,9 @@ TEST_CASE("Checking the identities required to vanish for the CT in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   auto result = ModelTests::CheckCTIdentities(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -260,13 +276,15 @@ TEST_CASE("Checking triple higgs NLO couplings in the CXSM", "[CXSM]")
 {
 
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   modelPointer->Prepare_Triple();
   modelPointer->TripleHiggsCouplings();
 
-  auto Check = [](auto result, auto expected) {
+  auto Check = [](auto result, auto expected)
+  {
     if (expected != 0)
     {
       REQUIRE(result == Approx(expected).epsilon(1e-4));
@@ -301,8 +319,9 @@ TEST_CASE("Checking triple higgs NLO couplings in the CXSM", "[CXSM]")
 TEST_CASE("Check number of calculated CT parameters in the CXSM", "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
   REQUIRE(ModelTests::TestResults::Pass ==
           ModelTests::CheckCTNumber(*modelPointer));
@@ -312,8 +331,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lij in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -325,8 +345,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijk in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -338,8 +359,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijkl in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -351,8 +373,9 @@ TEST_CASE("Check symmetric properties of the gauge tensor in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -364,8 +387,9 @@ TEST_CASE("Check symmetric properties of the Lepton tensor in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -377,8 +401,9 @@ TEST_CASE("Check symmetric properties of the mass Lepton tensor in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -390,8 +415,9 @@ TEST_CASE("Check symmetric properties of the mass quark tensor in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -403,8 +429,9 @@ TEST_CASE("Check symmetric properties of the quark tensor in the CXSM",
           "[CXSM]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::CXSM);
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SMConstants);
   modelPointer->initModel(example_point_CXSM);
 
   REQUIRE(ModelTests::TestResults::Pass ==

--- a/tests/unittests/Test-general.cpp
+++ b/tests/unittests/Test-general.cpp
@@ -10,11 +10,13 @@ using Approx = Catch::Approx;
 
 #include <BSMPT/models/IncludeAllModels.h>
 #include <BSMPT/models/ModelTestfunctions.h>
+#include <BSMPT/models/SMparam.h>
 
 TEST_CASE("Checking CKM Unitarity", "[general]")
 {
   using namespace BSMPT;
-  REQUIRE(ModelTests::CheckCKMUnitarity() == ModelTests::TestResults::Pass);
+  REQUIRE(ModelTests::CheckCKMUnitarity(GetSMConstants()) ==
+          ModelTests::TestResults::Pass);
 }
 
 TEST_CASE("Check get model", "[general]")

--- a/tests/unittests/Test-origin.cpp
+++ b/tests/unittests/Test-origin.cpp
@@ -29,8 +29,9 @@ const std::vector<double> example_point_C2HDM{/* lambda_1 = */ 3.29771,
 TEST_CASE("Check f_{abcd}", "[origin]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
   modelPointer->resetScale(200);
 

--- a/tests/unittests/Test-origin.cpp
+++ b/tests/unittests/Test-origin.cpp
@@ -24,6 +24,44 @@ const std::vector<double> example_point_C2HDM{/* lambda_1 = */ 3.29771,
                                               /* Re(m_{12}^2) = */ 2706.86,
                                               /* tan(beta) = */ 4.64487,
                                               /* Yukawa Type = */ 1};
+
+} // namespace
+
+TEST_CASE("Test Calculate Debye", "[origin]")
+{
+
+  using namespace BSMPT;
+  ISMConstants SM;
+  SM.C_MassTop = 172;
+  SM.C_vev0    = 246;
+
+  const std::vector<double> example_point_CXSM{/* vh = */ SM.C_vev0,
+                                               /* vs = */ 0,
+                                               /* va = */ 0,
+                                               /* ms = */ 41.67,
+                                               /* lambda = */ -0.002754092582,
+                                               /* delta2 = */ 0,
+                                               /* b2 = */ 0,
+                                               /* d2 = */ 0,
+                                               /* Reb1 = */ 0,
+                                               /* Imb1 = */ 0,
+                                               /* Rea1 = */ 0,
+                                               /* Ima1 = */ 0};
+
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::CXSM, SM);
+  modelPointer->initModel(example_point_CXSM);
+  modelPointer->CalculateDebye(true);
+  auto debye = modelPointer->get_DebyeHiggs();
+
+  double topCoupling = SM.C_MassTop * std::sqrt(2) / SM.C_vev0;
+  double expected    = std::pow(topCoupling, 2) / 4.0;
+
+  auto calculated = debye.at(3).at(3);
+
+  REQUIRE(calculated != 0);
+
+  REQUIRE(calculated == Approx(expected).margin(1e-3));
 }
 
 TEST_CASE("Check f_{abcd}", "[origin]")

--- a/tests/unittests/Test-origin.cpp
+++ b/tests/unittests/Test-origin.cpp
@@ -3,6 +3,10 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+/**
+ * @file
+ */
+
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
@@ -27,6 +31,10 @@ const std::vector<double> example_point_C2HDM{/* lambda_1 = */ 3.29771,
 
 } // namespace
 
+/**
+ * @test Check if the automatic Debye corrections match the SM one in the SM
+ * case. This should be y_t^2/4.
+ */
 TEST_CASE("Test Calculate Debye", "[origin]")
 {
 

--- a/tests/unittests/Test-r2hdm.cpp
+++ b/tests/unittests/Test-r2hdm.cpp
@@ -40,8 +40,9 @@ const std::vector<double> example_point_R2HDM_negTanBeta{
 TEST_CASE("Checking NLOVEV for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   std::vector<double> Check;
   auto sol = Minimizer::Minimize_gen_all(modelPointer,
@@ -60,8 +61,9 @@ TEST_CASE("Checking NLOVEV for R2HDM", "[r2hdm]")
 TEST_CASE("Checking EWPT for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   std::vector<double> Check;
   auto EWPT = Minimizer::PTFinder_gen_all(
@@ -97,7 +99,8 @@ TEST_CASE("Checking sign of SinBeta for pos. TanBeta", "[r2hdm]")
 {
   using namespace BSMPT;
   using namespace Models;
-  Class_Potential_R2HDM point;
+  const auto SMConstants = GetSMConstants();
+  Class_Potential_R2HDM point(SMConstants);
   point.set_gen(example_point_R2HDM);
   REQUIRE(point.C_SinBeta >= 0);
 }
@@ -106,7 +109,8 @@ TEST_CASE("Checking sign of SinBeta for neg. TanBeta", "[r2hdm]")
 {
   using namespace BSMPT;
   using namespace Models;
-  Class_Potential_R2HDM point;
+  const auto SMConstants = GetSMConstants();
+  Class_Potential_R2HDM point(SMConstants);
   point.set_gen(example_point_R2HDM_negTanBeta);
   REQUIRE(point.C_SinBeta <= 0);
 }
@@ -115,7 +119,8 @@ TEST_CASE("Checking sign of CosBeta for pos. TanBeta", "[r2hdm]")
 {
   using namespace BSMPT;
   using namespace Models;
-  Class_Potential_R2HDM point;
+  const auto SMConstants = GetSMConstants();
+  Class_Potential_R2HDM point(SMConstants);
   point.set_gen(example_point_R2HDM);
   REQUIRE(point.C_CosBeta >= 0);
 }
@@ -124,7 +129,8 @@ TEST_CASE("Checking sign of CosBeta for neg. TanBeta", "[r2hdm]")
 {
   using namespace BSMPT;
   using namespace Models;
-  Class_Potential_R2HDM point;
+  const auto SMConstants = GetSMConstants();
+  Class_Potential_R2HDM point(SMConstants);
   point.set_gen(example_point_R2HDM_negTanBeta);
   REQUIRE(point.C_CosBeta >= 0);
 }
@@ -132,8 +138,9 @@ TEST_CASE("Checking sign of CosBeta for neg. TanBeta", "[r2hdm]")
 TEST_CASE("Checking number of CT parameters for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckNumberOfCTParameters(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -142,8 +149,9 @@ TEST_CASE("Checking number of CT parameters for R2HDM", "[r2hdm]")
 TEST_CASE("Checking number of VEV labels for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckNumberOfVEVLabels(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -154,8 +162,9 @@ TEST_CASE(
     "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckLegendTemp(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -164,8 +173,9 @@ TEST_CASE(
 TEST_CASE("Checking number of triple Higgs couplings for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckNumberOfTripleCouplings(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -174,8 +184,9 @@ TEST_CASE("Checking number of triple Higgs couplings for R2HDM", "[r2hdm]")
 TEST_CASE("Checking Gauge Boson masses for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckGaugeBosonMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -184,8 +195,9 @@ TEST_CASE("Checking Gauge Boson masses for R2HDM", "[r2hdm]")
 TEST_CASE("Checking fermion and quark masses masses for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckFermionicMasses(*modelPointer);
   REQUIRE(result.first == ModelTests::TestResults::Pass);
@@ -195,8 +207,9 @@ TEST_CASE("Checking fermion and quark masses masses for R2HDM", "[r2hdm]")
 TEST_CASE("Checking tree level minimum for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckTreeLevelMin(*modelPointer,
                                               Minimizer::WhichMinimizerDefault);
@@ -206,8 +219,9 @@ TEST_CASE("Checking tree level minimum for R2HDM", "[r2hdm]")
 TEST_CASE("Checking tree level tadpoles for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckTadpoleRelations(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -216,8 +230,9 @@ TEST_CASE("Checking tree level tadpoles for R2HDM", "[r2hdm]")
 TEST_CASE("Checking NLO masses matching tree level masses for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckNLOMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -226,8 +241,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for R2HDM", "[r2hdm]")
 TEST_CASE("Checking VTreeSimplified for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   if (modelPointer->UseVTreeSimplified)
   {
     modelPointer->initModel(example_point_R2HDM);
@@ -243,8 +259,9 @@ TEST_CASE("Checking VTreeSimplified for R2HDM", "[r2hdm]")
 TEST_CASE("Checking VCounterSimplified for R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   if (modelPointer->UseVCounterSimplified)
   {
     modelPointer->initModel(example_point_R2HDM);
@@ -261,8 +278,9 @@ TEST_CASE("Checking first derivative of the sum of CT and CW in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckCTConditionsFirstDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -272,8 +290,9 @@ TEST_CASE("Checking second derivative of the sum of CT and CW in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   auto result = ModelTests::CheckCTConditionsSecondDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -283,8 +302,9 @@ TEST_CASE("Checking triple higgs NLO couplings in the R2HDM", "[r2hdm]")
 {
 
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   modelPointer->Prepare_Triple();
   modelPointer->TripleHiggsCouplings();
@@ -322,8 +342,9 @@ TEST_CASE("Checking triple higgs NLO couplings in the R2HDM", "[r2hdm]")
 TEST_CASE("Check number of calculated CT parameters in the R2HDM", "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
   REQUIRE(ModelTests::TestResults::Pass ==
           ModelTests::CheckCTNumber(*modelPointer));
@@ -333,8 +354,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lij in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -346,8 +368,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijk in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -359,8 +382,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijkl in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -372,8 +396,9 @@ TEST_CASE("Check symmetric properties of the gauge tensor in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -385,8 +410,9 @@ TEST_CASE("Check symmetric properties of the Lepton tensor in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -398,8 +424,9 @@ TEST_CASE("Check symmetric properties of the mass Lepton tensor in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -411,8 +438,9 @@ TEST_CASE("Check symmetric properties of the mass quark tensor in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -424,8 +452,9 @@ TEST_CASE("Check symmetric properties of the quark tensor in the R2HDM",
           "[r2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::R2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
   modelPointer->initModel(example_point_R2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==

--- a/tests/unittests/Test-rn2hdm.cpp
+++ b/tests/unittests/Test-rn2hdm.cpp
@@ -35,8 +35,9 @@ const Compare_RN2HDM Expected;
 TEST_CASE("Checking NLOVEV for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(Model);
+      ModelID::FChoose(Model, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   std::vector<double> Check;
   auto sol = Minimizer::Minimize_gen_all(modelPointer,
@@ -55,8 +56,9 @@ TEST_CASE("Checking NLOVEV for N2HDM", "[n2hdm]")
 TEST_CASE("Checking EWPT for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(Model);
+      ModelID::FChoose(Model, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   std::vector<double> Check;
   auto EWPT = Minimizer::PTFinder_gen_all(
@@ -89,8 +91,9 @@ TEST_CASE("Checking EWPT for N2HDM", "[n2hdm]")
 TEST_CASE("Checking number of CT parameters for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckNumberOfCTParameters(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -99,8 +102,9 @@ TEST_CASE("Checking number of CT parameters for N2HDM", "[n2hdm]")
 TEST_CASE("Checking number of VEV labels for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckNumberOfVEVLabels(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -111,8 +115,9 @@ TEST_CASE(
     "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckLegendTemp(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -121,8 +126,9 @@ TEST_CASE(
 TEST_CASE("Checking number of triple Higgs couplings for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckNumberOfTripleCouplings(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -131,8 +137,9 @@ TEST_CASE("Checking number of triple Higgs couplings for N2HDM", "[n2hdm]")
 TEST_CASE("Checking Gauge Boson masses for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckGaugeBosonMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -141,8 +148,9 @@ TEST_CASE("Checking Gauge Boson masses for N2HDM", "[n2hdm]")
 TEST_CASE("Checking fermion and quark masses masses for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckFermionicMasses(*modelPointer);
   REQUIRE(result.first == ModelTests::TestResults::Pass);
@@ -152,8 +160,9 @@ TEST_CASE("Checking fermion and quark masses masses for N2HDM", "[n2hdm]")
 TEST_CASE("Checking tree level minimum for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckTreeLevelMin(*modelPointer,
                                               Minimizer::WhichMinimizerDefault);
@@ -163,8 +172,9 @@ TEST_CASE("Checking tree level minimum for N2HDM", "[n2hdm]")
 TEST_CASE("Checking tree level tadpoles for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckTadpoleRelations(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -173,8 +183,9 @@ TEST_CASE("Checking tree level tadpoles for N2HDM", "[n2hdm]")
 TEST_CASE("Checking NLO masses matching tree level masses for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckNLOMasses(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -183,8 +194,9 @@ TEST_CASE("Checking NLO masses matching tree level masses for N2HDM", "[n2hdm]")
 TEST_CASE("Checking VTreeSimplified for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   if (modelPointer->UseVTreeSimplified)
   {
     modelPointer->initModel(example_point_RN2HDM);
@@ -200,8 +212,9 @@ TEST_CASE("Checking VTreeSimplified for N2HDM", "[n2hdm]")
 TEST_CASE("Checking VCounterSimplified for N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   if (modelPointer->UseVCounterSimplified)
   {
     modelPointer->initModel(example_point_RN2HDM);
@@ -218,8 +231,9 @@ TEST_CASE("Checking first derivative of the sum of CT and CW in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckCTConditionsFirstDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -229,8 +243,9 @@ TEST_CASE("Checking second derivative of the sum of CT and CW in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   auto result = ModelTests::CheckCTConditionsSecondDerivative(*modelPointer);
   REQUIRE(result == ModelTests::TestResults::Pass);
@@ -240,13 +255,15 @@ TEST_CASE("Checking triple higgs NLO couplings in the N2HDM", "[n2hdm]")
 {
 
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   modelPointer->Prepare_Triple();
   modelPointer->TripleHiggsCouplings();
 
-  auto Check = [](auto result, auto expected) {
+  auto Check = [](auto result, auto expected)
+  {
     if (std::abs(expected) > 1e-4)
     {
       REQUIRE(result == Approx(expected).epsilon(1e-4));
@@ -278,8 +295,9 @@ TEST_CASE("Checking triple higgs NLO couplings in the N2HDM", "[n2hdm]")
 TEST_CASE("Check number of calculated CT parameters in the N2HDM", "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
   REQUIRE(ModelTests::TestResults::Pass ==
           ModelTests::CheckCTNumber(*modelPointer));
@@ -289,8 +307,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lij in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -302,8 +321,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijk in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -315,8 +335,9 @@ TEST_CASE("Check symmetric properties of the scalar tensor Lijkl in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -328,8 +349,9 @@ TEST_CASE("Check symmetric properties of the gauge tensor in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -341,8 +363,9 @@ TEST_CASE("Check symmetric properties of the Lepton tensor in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -354,8 +377,9 @@ TEST_CASE("Check symmetric properties of the mass Lepton tensor in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -367,8 +391,9 @@ TEST_CASE("Check symmetric properties of the mass quark tensor in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==
@@ -380,8 +405,9 @@ TEST_CASE("Check symmetric properties of the quark tensor in the N2HDM",
           "[n2hdm]")
 {
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::RN2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::RN2HDM, SMConstants);
   modelPointer->initModel(example_point_RN2HDM);
 
   REQUIRE(ModelTests::TestResults::Pass ==

--- a/tests/unittests/baryotests/Test-baryo-c2hdm.cpp
+++ b/tests/unittests/baryotests/Test-baryo-c2hdm.cpp
@@ -93,8 +93,8 @@ void CheckFileForConfig(const std::string &filename,
   std::pair<std::vector<bool>, int> config;
   try
   {
-    BSMPT::Baryo::CalculateEtaInterface etaInterface(std::vector<bool>(5, true),
-                                                     1);
+    BSMPT::Baryo::CalculateEtaInterface etaInterface(
+        std::vector<bool>(5, true), 1, BSMPT::GetSMConstants());
     config = etaInterface.ReadConfigFile(filename);
   }
   catch (std::exception &e)
@@ -132,7 +132,9 @@ const Compare_C2HDM Expected;
 
 TEST_CASE("Checking EWBG for C2HDM", "[c2hdm]")
 {
+
   using namespace BSMPT;
+  const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
       ModelID::FChoose(ModelID::ModelIDs::C2HDM);
   modelPointer->initModel(example_point_C2HDM);
@@ -163,7 +165,7 @@ TEST_CASE("Checking EWBG for C2HDM", "[c2hdm]")
 
   auto config =
       std::pair<std::vector<bool>, int>{std::vector<bool>(5, true), 1};
-  Baryo::CalculateEtaInterface EtaInterface(config);
+  Baryo::CalculateEtaInterface EtaInterface(config, SMConstants);
   const double testVW = Expected.testVW;
 
   REQUIRE(EWPT.vc > EWPT.Tc);

--- a/tests/unittests/baryotests/Test-baryo-c2hdm.cpp
+++ b/tests/unittests/baryotests/Test-baryo-c2hdm.cpp
@@ -136,7 +136,7 @@ TEST_CASE("Checking EWBG for C2HDM", "[c2hdm]")
   using namespace BSMPT;
   const auto SMConstants = GetSMConstants();
   std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
-      ModelID::FChoose(ModelID::ModelIDs::C2HDM);
+      ModelID::FChoose(ModelID::ModelIDs::C2HDM, SMConstants);
   modelPointer->initModel(example_point_C2HDM);
 
   const auto WhichMin = Minimizer::WhichMinimizerDefault;


### PR DESCRIPTION
The goal of this PR is to add a small unit test to check if the calculated Debye corrections matches the expected y_t^2/4. 
For this I had to change how the models get the SM constants. It is now a struct which contains the constants.
The `CalcEtaInterface` and `FChoose` had a small API break. To get the old behaviour the new argument can be set to the function `GetSMConstants()` in which case everything is the same as before.
For unit tests, and maybe others if wanted, can now choose other SM parameters easily.