### PR TITLE
Add Joao to CodeOwner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @phbasler @lisabiermann @JonasMueller1991
+* @phbasler @lisabiermann @JonasMueller1991 @vollous


### PR DESCRIPTION
With the preparation of v3 I propose making Joao a Codeowner to allow him to make reviews.