### PR TITLE
Reduce diagonal runtime of HessianNumerical

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
     branches: 
       - master
       - develop
-      - BSMPTv3
   workflow_dispatch:
     
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,13 @@ name: Unit tests
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master, develop ]
+    branches: 
+      - master
+      - develop
+      - BSMPTv3
   workflow_dispatch:
     
 

--- a/src/utility/NumericalDerivatives.cpp
+++ b/src/utility/NumericalDerivatives.cpp
@@ -34,8 +34,21 @@ HessianNumerical(const std::vector<double> &phi,
                                           std::vector<double>(phi.size()));
   for (size_t i = 0; i < phi.size(); i++)
   {
+    double val = 0;
+    auto xp = phi;
+    xp[i]+= 2*eps;
+    val += V(xp);
+
+    val -= 2*V(phi);
+
+    xp = phi;
+    xp[i] -= 2*eps;
+    val += V(xp);
+
+    result[i][i] = val/(4*eps*eps);
+
     // https://en.wikipedia.org/wiki/Finite_difference
-    for (size_t j = i; j < phi.size(); j++)
+    for (size_t j = i+1; j < phi.size(); j++)
     {
       double r = 0;
 

--- a/src/utility/NumericalDerivatives.cpp
+++ b/src/utility/NumericalDerivatives.cpp
@@ -35,20 +35,20 @@ HessianNumerical(const std::vector<double> &phi,
   for (size_t i = 0; i < phi.size(); i++)
   {
     double val = 0;
-    auto xp = phi;
-    xp[i]+= 2*eps;
+    auto xp    = phi;
+    xp[i] += 2 * eps;
     val += V(xp);
 
-    val -= 2*V(phi);
+    val -= 2 * V(phi);
 
     xp = phi;
-    xp[i] -= 2*eps;
+    xp[i] -= 2 * eps;
     val += V(xp);
 
-    result[i][i] = val/(4*eps*eps);
+    result[i][i] = val / (4 * eps * eps);
 
     // https://en.wikipedia.org/wiki/Finite_difference
-    for (size_t j = i+1; j < phi.size(); j++)
+    for (size_t j = i + 1; j < phi.size(); j++)
     {
       double r = 0;
 


### PR DESCRIPTION
Reduce runtime by simplifying the formula in the loop for diagonal elements and start the loop by running from `j=i+1` 