### PR TITLE
Conan use default profile

### DIFF
--- a/Setup.py
+++ b/Setup.py
@@ -64,9 +64,14 @@ def get_profile(os: str, arch: str, build_type: BuildMode):
 def check_profile(profile):
     path = os.path.join("profiles", "BSMPT", profile)
     if not os.path.isfile(path):
-        raise Exception(
-            f"The desired profile {profile} does not exist in BSMPT/profiles. Please create it."
-        )
+        print(f"Profile does not exist in BSMPT/profiles.\nUsing profile {profile} created from the default profile. Change it accordingly.")
+        cmd = "conan profile detect -f".split()
+        subprocess.check_output(cmd)
+        conan_home = subprocess.check_output("conan config home".split(), encoding="UTF-8").split("\n")[0]
+        cmd = "cp " + conan_home + "/profiles/default profiles/BSMPT/" + str(profile)
+        subprocess.check_call(cmd, shell=True)
+        setup_profiles()
+        check_profile(profile)
 
 
 def get_gcc_version():

--- a/Setup.py
+++ b/Setup.py
@@ -69,7 +69,10 @@ def check_profile(profile):
         if not os.path.isfile(conan_home + "/profiles/default"):
             cmd = "conan profile detect".split()
             subprocess.check_output(cmd)
-        cmd = "cp " + conan_home + "/profiles/default profiles/BSMPT/" + str(profile)
+        if (sys.platform != "win32"):
+            cmd = "cp " + conan_home + "/profiles/default profiles/BSMPT/" + str(profile)
+        else:
+            cmd = "copy " + conan_home + "\\profiles\\default profiles\\BSMPT\\" + str(profile)
         subprocess.check_call(cmd, shell=True)
         setup_profiles()
         check_profile(profile)

--- a/Setup.py
+++ b/Setup.py
@@ -3,6 +3,7 @@ import sys
 import os
 import shutil
 from enum import Enum
+import fileinput
 from argparse import ArgumentParser, ArgumentTypeError
 import platform
 
@@ -60,6 +61,11 @@ def get_profile(os: str, arch: str, build_type: BuildMode):
 
     return profile
 
+def set_setting(file, setting, value):
+    for line in fileinput.input([file], inplace=True):
+        if line.strip().startswith(setting):
+            line = setting + "=" + value + "\n"
+        sys.stdout.write(line)
 
 def check_profile(profile):
     path = os.path.join("profiles", "BSMPT", profile)
@@ -71,9 +77,14 @@ def check_profile(profile):
             subprocess.check_output(cmd)
         if (sys.platform != "win32"):
             cmd = "cp " + conan_home + "/profiles/default profiles/BSMPT/" + str(profile)
+            subprocess.check_call(cmd, shell=True)
+            set_setting(path, "compiler.cppstd", "gnu17")
+           
         else:
             cmd = "copy " + conan_home + "\\profiles\\default profiles\\BSMPT\\" + str(profile)
-        subprocess.check_call(cmd, shell=True)
+            subprocess.check_call(cmd, shell=True)
+            set_setting(path, "compiler.cppstd", "17")
+
         setup_profiles()
         check_profile(profile)
 

--- a/Setup.py
+++ b/Setup.py
@@ -64,10 +64,11 @@ def get_profile(os: str, arch: str, build_type: BuildMode):
 def check_profile(profile):
     path = os.path.join("profiles", "BSMPT", profile)
     if not os.path.isfile(path):
-        print(f"Profile does not exist in BSMPT/profiles.\nUsing profile {profile} created from the default profile. Change it accordingly.")
-        cmd = "conan profile detect -f".split()
-        subprocess.check_output(cmd)
         conan_home = subprocess.check_output("conan config home".split(), encoding="UTF-8").split("\n")[0]
+        print(f"Profile does not exist in BSMPT/profiles.\nUsing profile {profile} created from the default profile. Change it accordingly.")
+        if not os.path.isfile(conan_home + "/profiles/default"):
+            cmd = "conan profile detect".split()
+            subprocess.check_output(cmd)
         cmd = "cp " + conan_home + "/profiles/default profiles/BSMPT/" + str(profile)
         subprocess.check_call(cmd, shell=True)
         setup_profiles()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile
+from conan import ConanFile, tools
 from conan.tools.cmake import cmake_layout, CMakeToolchain
 from conan.tools.system.package_manager import Apt
 from conan.errors import ConanInvalidConfiguration
@@ -82,3 +82,5 @@ class BSMPT(ConanFile):
 
         if self.settings.os != "Linux" and self.options.EnableCoverage:
             raise ConanInvalidConfiguration("We depend on lcov for coverage.")
+        
+        tools.build.check_min_cppstd(self, "17")


### PR DESCRIPTION
If conan cannot match with any profile shipped with BSMPT v3, we create a new profile equal to the default profile and use that one.