### PR TITLE
Add functional.h to utility.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.23)
 project(
   BSMPT
-  VERSION 3.0.1
+  VERSION 3.0.2
   LANGUAGES C CXX
   DESCRIPTION
     "BSMPT - Beyond the Standard Model Phase Transitions : A C++ package for the computation of the EWPT in BSM models"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.0.1
+Program: BSMPT version 3.0.2
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/include/BSMPT/utility/utility.h
+++ b/include/BSMPT/utility/utility.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <gsl/gsl_integration.h>
 #include <iostream>
+#include <functional>
 #include <numeric>
 #include <random>
 #include <string>

--- a/include/BSMPT/utility/utility.h
+++ b/include/BSMPT/utility/utility.h
@@ -8,9 +8,9 @@
 
 #include <BSMPT/config.h>
 #include <algorithm>
+#include <functional>
 #include <gsl/gsl_integration.h>
 #include <iostream>
-#include <functional>
 #include <numeric>
 #include <random>
 #include <string>


### PR DESCRIPTION
Out of nowhere the code complained about a missing header file ```functional.h``` in ```utility.h```.

Should we also bump the bug version with this fix?