### PR TITLE
Fix transition history for multi-step transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.23)
 project(
   BSMPT
-  VERSION 3.0.3
+  VERSION 3.0.4
   LANGUAGES C CXX
   DESCRIPTION
     "BSMPT - Beyond the Standard Model Phase Transitions : A C++ package for the computation of the EWPT in BSM models"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.0.3
+Program: BSMPT version 3.0.4
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/src/transition_tracer/transition_tracer.cpp
+++ b/src/transition_tracer/transition_tracer.cpp
@@ -413,6 +413,7 @@ TransitionTracer::TransitionTracer(user_input &input)
           // store current false phase
           transition_history.push_back(tmp_phase_id);
           tmp_next_phase_id = -1;
+          tmp_compl_temp    = -1;
 
           for (auto pair : vec_coex)
           {


### PR DESCRIPTION
The temporary storage of the completion temperature used in the check for the transition history was not reset after a found transition. Therefore, only histories for one-step first-order PTs were reported correctly. This PR fixes that.
Thanks to @karoerhardt for pointing this out to us!