### PR TITLE
Match convention with ClassPotentialSM.cpp

### DIFF
--- a/include/BSMPT/models/ClassPotentialSM.h
+++ b/include/BSMPT/models/ClassPotentialSM.h
@@ -20,9 +20,46 @@ namespace Models
 
 /**
  * @brief The Class_SM class
- * Implementation of the SM
+ * Implementation of the Standard Model
+ *
+ *
+ * * \f$ -L_S = muSq \Phi^\dagger \Phi + lambda (\Phi^\dagger \Phi)^2 \f$
+ * * \f$ -L_Y = \overline{U}_L V \text{diag}(y_d,y_s,y_b) D_R \Phi^+  +
+ * \overline{D}_L \text{diag}(y_d,y_s,y_b) D_R \Phi^0 + \overline{U}_L
+ * \text{diag}(y_u, y_c, y_t) U_R (\Phi^0)^\ast - \overline{D}_L V^\dagger
+ * \text{diag}(y_u, y_c, y_t) U_R \Phi^- + \overline{E}_L \text{diag}(y_e,
+ * y_\mu, y_\tau) E_R \Phi^0 +\overline{\nu}_L \text{diag}(y_e, y_\mu, y_\tau)
+ * E_R \Phi^+ + c.c.  \f$
+ * * \f$ L_G = (D_\mu \Phi)^\dagger (D^\mu \Phi) \f$
+ *
+ * with
+ *
+ * * \f$ \Phi = \begin{pmatrix} \Phi^+ \\  \Phi^0 \end{pmatrix} =
+ * 1/\sqrt{2} \begin{pmatrix} higgsbase[0] + I*higgsbase[1] \\  higgsbase[2] + I
+ * *higgsbase[3] \end{pmatrix}\,, \f$
+ * * \f$ D_\mu = -I C\_{}g/2 * W_\mu^a \sigma^a -I C\_{}gs/2 B_\mu =
+ * -\frac{I}{2} \begin{pmatrix} C\_{}gs B + C\_{}g W3  & C\_{}g (W1 -I W2) \\
+ * C\_{}g (W1 +I W2) & C\_{}gs B - C\_{}g W3 \end{pmatrix} \f$ with the gauge
+ * base = [W1,W2,W3,B]
+ *
+ * * \f$ \overline{U}_L = \begin{pmatrix} \overline{u}_L &  \overline{c}_L &
+ * \overline{t}_L \end{pmatrix}\,, \f$
+ * * \f$ U_R = \begin{pmatrix} u_R \\ c_R \\ t_R \end{pmatrix}\,, \f$
+ * * \f$ \overline{D}_L = \begin{pmatrix} \overline{d}_L & \overline{s}_L &
+ * \overline{b}_L \end{pmatrix}\,, \f$
+ * * \f$ D_R = \begin{pmatrix} d_R \\ s_R \\ b_R \end{pmatrix}\,, \f$
+ * * \f$ \overline{E}_L = \begin{pmatrix} \overline{e}_L & \overline{\mu}_L &
+ * \overline{\tau}_L \end{pmatrix}\,, \f$
+ * * \f$ E_R = \begin{pmatrix} e_R \\ \mu_R \\ \tau_R \end{pmatrix}\,, \f$
+ * * \f$ \overline{\nu}_L = \begin{pmatrix} \overline{\nu}_{e,L} &
+ * \overline{\nu}_{\mu,L} & \overline{\nu}_{\tau,L} \end{pmatrix} \f$
+ *
+ * The basis of the quarks given by \f$ [u_R, c_R, t_R, d_R, s_R, b_R,
+ * \overline{u}_L, \overline{c}_L, \overline{t}_L, \overline{d}_L,
+ * \overline{s}_L, \overline{b}_L ] \f$ and for the leptons \f$ [\overline{e}_L,
+ * e_R, \overline{\mu}_L , \mu_R, \overline{\tau}_L, \tau_R,
+ * \overline{\nu}_{e,L}, \overline{\nu}_{\mu,L}, \overline{\nu}_{\tau,L} ] \f$
  */
-
 class Class_SM : public Class_Potential_Origin
 {
 public:

--- a/tools/ModelGeneration/sympy/SM.py
+++ b/tools/ModelGeneration/sympy/SM.py
@@ -31,12 +31,12 @@ Vud,Vus,Vub,Vcd,Vcs,Vcb,Vtd,Vts,Vtb = symbols('Vud Vus Vub Vcd Vcs Vcb Vtd Vts V
 VCKM = Matrix([[Vud,Vus,Vub],[Vcd,Vcs,Vcb],[Vtd,Vts,Vtb]])
 
 #parameters
-msq, la = symbols('msq lambda', real=True)
-params=[msq,la]
+muSq, lamb = symbols('muSq lambda', real=True)
+params=[muSq,lamb]
 
 #CT params
-dmsq, dla = symbols('dmsq dlambda', real=True)
-dparams=[dmsq,dla]
+dmuSq, dlamb = symbols('dmuSq dlambda', real=True)
+dparams=[dmuSq,dlamb]
 
 #VEVs
 v = symbols('v', real=True)
@@ -55,11 +55,10 @@ finiteTempVEV = zeroTempVEV
 fieldsZero = [(x,0) for x in Higgsfields]
 
 phiSq = simplify((Dagger(phi)*phi)[0])
-VHiggs = msq/2 * phiSq + la/factorial(4) * phiSq**2
+VHiggs = muSq * phiSq + lamb * phiSq**2
 
 # Set Gauge fields
 W1, W2, W3, B0 = symbols('W1 W2 W3 B0',real=True)
-
 
 Dmu = -I*Cg/2 * (sigma1*W1 + sigma2 * W2 + sigma3*W3) -I*Cgs/2 * sigma0 * B0
 VGauge = simplify(Dagger(Dmu*phi)*(Dmu*phi))[0,0]
@@ -85,14 +84,14 @@ for i in range(len(EL)):
         VFLep += (EL[i] * PiLep[i,j] * ER[j])*phi[1]
 
 VFLep = simplify(VFLep)
-LepBase = NuL + ER + EL
+LepBase = symbols('eL eR muL muR tauL tauR veL vmuL vtauL', real=True)
 
 # Generate Quark Potentials
 UL = symbols('uL cL tL', real=True)
 DL = symbols('dL sL bL', real=True)
 UR = symbols('uR cR tR', real=True)
 DR = symbols('dR sR bR', real=True)
-QuarkBase = UL + DL + UR + DR
+QuarkBase = UR + DR + UL + DL
 
 yb = sqrt(2)*m_bottom/v
 yc = sqrt(2)*m_charm/v
@@ -116,16 +115,11 @@ VQuark+= -DLVector.transpose() * Dagger(VCKM)*UpCoupling*URVector*phi[0].conjuga
 VQuark = simplify(VQuark[0,0])
 
 
-
 # Generate the model
 toyModel = ModelGenerator.ModelGenerator(params,dparams,CTTadpoles,Higgsfields,VHiggs,zeroTempVEV,finiteTempVEV)
 toyModel.setGauge([W1,W2,W3,B0],VGauge)
 toyModel.setLepton(LepBase, VFLep)
 toyModel.setQuark(QuarkBase, VQuark)
-
-
-
-
 
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Changes the potential convention and fermion basis order to match the tensors in `ClassPotentialSM.cpp`.