### PR TITLE
Dont try to autocommit on dependabot or fork jobs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     env:
-      LocalCommit: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+      LocalCommit:  github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
   
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ secrets.LINTER_PAT }}
-        if: !env.LocalCommit
+        if: ${{ !env.LocalCommit }}
 
       - name: Install clang-format
         if: inputs.apply_clang_format
@@ -74,7 +74,7 @@ jobs:
           git push
 
       - name: Notify that changes are required
-        if: steps.check-changes.outputs.ChangesFound == 'True' && !env.LocalCommit
+        if: ${{ steps.check-changes.outputs.ChangesFound == 'True' && !env.LocalCommit }}
         run: |
           echo "Linter changes are required" >> $GITHUB_STEP_SUMMARY
           exit 1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,6 @@ jobs:
       LocalCommit:  ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
   
     steps:
-      - run: echo ${{ env.LocalCommit }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     env:
-      LocalCommit:  github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+      LocalCommit:  ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
   
     steps:
       - run: echo ${{ env.LocalCommit }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,17 +15,18 @@ jobs:
       LocalCommit:  github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
   
     steps:
+      - run: echo ${{ env.LocalCommit }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.LINTER_PAT }}
         if: env.LocalCommit
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.LINTER_PAT }}
         if: ${{ !env.LocalCommit }}
 
       - run: git fetch origin $GITHUB_BASE_REF

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,13 +11,22 @@ concurrency:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    env:
+      LocalCommit: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
   
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+        if: env.LocalCommit
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.LINTER_PAT }}
+        if: !env.LocalCommit
 
       - name: Install clang-format
         if: inputs.apply_clang_format
@@ -59,8 +68,14 @@ jobs:
           git config user.email "<>"
 
       - name: Commit changes
-        if: steps.check-changes.outputs.ChangesFound == 'True'
+        if: steps.check-changes.outputs.ChangesFound == 'True' && env.LocalCommit
         run: |
           git commit -am "Automatically applied linter"
           git push
+
+      - name: Notify that changes are required
+        if: steps.check-changes.outputs.ChangesFound == 'True' && !env.LocalCommit
+        run: |
+          echo "Linter changes are required" >> $GITHUB_STEP_SUMMARY
+          exit 1
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,10 +28,6 @@ jobs:
           token: ${{ secrets.LINTER_PAT }}
         if: ${{ !env.LocalCommit }}
 
-      - name: Install clang-format
-        if: inputs.apply_clang_format
-        run: pip3 install clang-format==14.0.0
-
       - run: git fetch origin $GITHUB_BASE_REF
 
       - name: Set Branch name

--- a/src/minimizer/LibCMAES/MinimizeLibCMAES.cpp
+++ b/src/minimizer/LibCMAES/MinimizeLibCMAES.cpp
@@ -30,8 +30,7 @@ namespace LibCMAES
 
 using namespace libcmaes;
 
-LibCMAESReturn min_cmaes_gen_all(const Class_Potential_Origin &model,
-                                 const double &Temp,
+LibCMAESReturn min_cmaes_gen_all(const Class_Potential_Origin &model,                                 const double &Temp,
                                  const std::vector<double> &Start)
 {
 

--- a/src/minimizer/LibCMAES/MinimizeLibCMAES.cpp
+++ b/src/minimizer/LibCMAES/MinimizeLibCMAES.cpp
@@ -30,7 +30,8 @@ namespace LibCMAES
 
 using namespace libcmaes;
 
-LibCMAESReturn min_cmaes_gen_all(const Class_Potential_Origin &model,                                 const double &Temp,
+LibCMAESReturn min_cmaes_gen_all(const Class_Potential_Origin &model,
+                                 const double &Temp,
                                  const std::vector<double> &Start)
 {
 


### PR DESCRIPTION
Fixes the linter workflow to not fail on fork or dependabot PRs because of missing write access.
Instead it will fail if there are changes necessary.