### PR TITLE
Remove test for ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   tests-fullSetup:
     strategy:
       matrix:
-        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-latest}, {os: ubuntu-20.04}] 
+        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-latest}] 
     runs-on: ${{matrix.setup.os}}
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
 


### PR DESCRIPTION
Removing the test workflow for ubuntu 20.04 and only keeping latest