### PR TITLE
Set coverage workflow to 22.04 to avoid segfaults

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,7 @@ on:
       - '**.hpp'
       - '**CMakeLists.txt'
       - 'conanfile.py'
+      - '.github/workflows/codecov.yml'
   workflow_dispatch:
 
 concurrency:
@@ -31,7 +32,7 @@ concurrency:
   
 jobs:  
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     
     steps:


### PR DESCRIPTION
The code coverage workflow has some segfaults since `ubuntu-latest` is ubuntu 24.04.
This may be due to the upgrade of gcc (v11 to v13) or due to some other dependencies.
This PR fixes the runner to ubuntu 22.04 to avoid this until we can fix the real problem.