### PR TITLE
Fix cmake generation with cmake v4

### DIFF
--- a/tools/cmake/LTO.cmake
+++ b/tools/cmake/LTO.cmake
@@ -51,8 +51,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.1)
-
 option(ENABLE_LTO "enable link time optimization" ON)
 
 macro(find_lto lang)


### PR DESCRIPTION
Fix cmake generaton for cmake 4.0.0 by removing unsupported version check
Closes #210 