### PR TITLE
Use -dumpversion flag to get gcc/clang version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.23)
-set(BSMPT_VERSION 3.1.2)
+set(BSMPT_VERSION 3.1.3)
 project(
   BSMPT
   VERSION ${BSMPT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.1.2
+Program: BSMPT version 3.1.3
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/Setup.py
+++ b/Setup.py
@@ -121,7 +121,7 @@ def get_compiler_version(compiler: Compiler):
     if sys.platform == "linux" and compiler != Compiler.clang:
         semver_string = subprocess.check_output(
             "gcc -dumpversion".split(), encoding="UTF-8"
-        )#.split("\n")[0]
+        ).split("\n")[0]
         print("call response|", semver_string, "|end")
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:

--- a/Setup.py
+++ b/Setup.py
@@ -120,7 +120,6 @@ def get_compiler_version(compiler: Compiler):
         semver_string = subprocess.check_output(
             "gcc -dumpversion".split(), encoding="UTF-8"
         ).split("\n")[0]
-        print("call response|", semver_string, "|end")
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:
         semver_string = subprocess.check_output(

--- a/Setup.py
+++ b/Setup.py
@@ -117,16 +117,14 @@ def check_profile(profile):
 
 def get_compiler_version(compiler: Compiler):
     if sys.platform == "linux" and compiler != Compiler.clang:
-        version_response = subprocess.check_output(
+        semver_string = subprocess.check_output(
             "gcc -dumpversion".split(), encoding="UTF-8"
-        ).partition("\n")[0]
-        semver_string = version_response[version_response.rfind(" ") + 1 :]
+        )
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:
-        version_response = subprocess.check_output(
+        semver_string = subprocess.check_output(
             "clang -dumpversion".split(), encoding="UTF-8"
-        ).partition("\n")[0]
-        semver_string = version_response[version_response.rfind("version") + 8 :]
+        )
         return semver_string.partition(".")[0]
     return ""
 

--- a/Setup.py
+++ b/Setup.py
@@ -121,7 +121,7 @@ def get_compiler_version(compiler: Compiler):
     if sys.platform == "linux" and compiler != Compiler.clang:
         semver_string = subprocess.check_output(
             "gcc -dumpversion".split(), encoding="UTF-8"
-        ).split("\n")[0]
+        )#.split("\n")[0]
         print("call response|", semver_string, "|end")
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:

--- a/Setup.py
+++ b/Setup.py
@@ -121,7 +121,8 @@ def get_compiler_version(compiler: Compiler):
     if sys.platform == "linux" and compiler != Compiler.clang:
         semver_string = subprocess.check_output(
             "gcc -dumpversion".split(), encoding="UTF-8"
-        )
+        ).split("\n")[0]
+        print("call response|", semver_string, "|end")
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:
         semver_string = subprocess.check_output(

--- a/Setup.py
+++ b/Setup.py
@@ -118,13 +118,13 @@ def check_profile(profile):
 def get_compiler_version(compiler: Compiler):
     if sys.platform == "linux" and compiler != Compiler.clang:
         version_response = subprocess.check_output(
-            "gcc --version".split(), encoding="UTF-8"
+            "gcc -dumpversion".split(), encoding="UTF-8"
         ).partition("\n")[0]
         semver_string = version_response[version_response.rfind(" ") + 1 :]
         return semver_string.partition(".")[0]
     elif sys.platform == "darwin" or compiler == Compiler.clang:
         version_response = subprocess.check_output(
-            "clang --version".split(), encoding="UTF-8"
+            "clang -dumpversion".split(), encoding="UTF-8"
         ).partition("\n")[0]
         semver_string = version_response[version_response.rfind("version") + 8 :]
         return semver_string.partition(".")[0]

--- a/Setup.py
+++ b/Setup.py
@@ -48,6 +48,8 @@ def get_compiler(compiler: Compiler):
         compilerString += "-clang-"
     compilerString += get_compiler_version(compiler)
 
+    print("Found compiler ", compilerString)
+
     return compilerString
 
 

--- a/Setup.py
+++ b/Setup.py
@@ -48,8 +48,6 @@ def get_compiler(compiler: Compiler):
         compilerString += "-clang-"
     compilerString += get_compiler_version(compiler)
 
-    print("Found compiler ", compilerString)
-
     return compilerString
 
 


### PR DESCRIPTION
## Description

This patch uses the `-dumpversion` flag of compilers to get the compiler version.
<!-- Provide a brief description of the change and the purpose of the PR. -->

## Type of Change

<!-- Please select only a single option with an "x" or "X". -->

 - [ ] Break (major)
 - [ ] Feature (minor)
 - [x] Bug fix (patch)
 - [ ] No source changes (no version change)
