### PR TITLE
Fix compile error with clang 14 on mac

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
+    - name: Install LLVM (Clang 14) via Homebrew
+      if: runner.os == 'macOS'
+      run: |
+        brew install llvm@14
+        echo "PATH=$(brew --prefix llvm@14)/bin:$PATH" >> $GITHUB_ENV
+
     - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,11 @@ jobs:
         brew install llvm@14
         echo "PATH=$(brew --prefix llvm@14)/bin:$PATH" >> $GITHUB_ENV
 
+    - if: runner.os == 'macOS'
+      run: |
+        clang --version
+        clang++ --version
+
     - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   tests-fullSetup:
     strategy:
       matrix:
-        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-latest}] 
+        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-13}] 
     runs-on: ${{matrix.setup.os}}
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   tests-fullSetup:
     strategy:
       matrix:
-        setup: [ {os: macos-13}] 
+        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-latest} ] 
     runs-on: ${{matrix.setup.os}}
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
 
@@ -31,12 +31,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
           persist-credentials: false
-
-    - name: Install LLVM (Clang 14) via Homebrew
-      if: runner.os == 'macOS'
-      run: |
-        brew install llvm@14
-        echo "PATH=$(brew --prefix llvm@14)/bin:$PATH" >> $GITHUB_ENV
         
     - uses: actions/setup-python@v5
       with:
@@ -48,13 +42,6 @@ jobs:
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
-
-
-
-    - if: runner.os == 'macOS'
-      run: |
-        clang --version
-        clang++ --version
 
     - uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   tests-fullSetup:
     strategy:
       matrix:
-        setup: [ {os: ubuntu-latest}, {os: windows-latest}, {os: macos-13}] 
+        setup: [ {os: macos-13}] 
     runs-on: ${{matrix.setup.os}}
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
 
@@ -31,6 +31,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
           persist-credentials: false
+
+    - name: Install LLVM (Clang 14) via Homebrew
+      if: runner.os == 'macOS'
+      run: |
+        brew install llvm@14
+        echo "PATH=$(brew --prefix llvm@14)/bin:$PATH" >> $GITHUB_ENV
+        
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
@@ -42,11 +49,7 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
-    - name: Install LLVM (Clang 14) via Homebrew
-      if: runner.os == 'macOS'
-      run: |
-        brew install llvm@14
-        echo "PATH=$(brew --prefix llvm@14)/bin:$PATH" >> $GITHUB_ENV
+
 
     - if: runner.os == 'macOS'
       run: |

--- a/Build.py
+++ b/Build.py
@@ -31,7 +31,7 @@ def build(preset):
 
 def main():
     opts = Setup.parse_arguments()
-    Setup.setup_profiles()
+    Setup.prepare()
     Setup.conan_install_all(Setup.BuildMode.release,
                             opts.options if opts.options is not None else [],
                             build_missing=True,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.23)
-set(BSMPT_VERSION 3.1.1)
+set(BSMPT_VERSION 3.1.2)
 project(
   BSMPT
   VERSION ${BSMPT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 Philipp Basler, Margarete Mühlleitner and Jonas M�
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-Program: BSMPT version 3.1.1
+Program: BSMPT version 3.1.2
 
 Released by: Philipp Basler, Lisa Biermann, Margarete Mühlleitner, Jonas Müller, Rui Santos and João Viana
 

--- a/Setup.py
+++ b/Setup.py
@@ -187,8 +187,7 @@ def conan_install(
     profile, additional_options=[], build_missing=False, compiler: Compiler = None
 ):
     config_settings = [
-        "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']",
-        "tools.build:compiler_executables={'c':'/usr/local/opt/llvm@14/bin/clang', 'cpp': '/usr/local/opt/llvm@14/bin/clang++'}"
+        "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']"
     ]
 
     build_profile = get_profile(sys.platform, get_arch(), BuildMode.release, compiler)

--- a/Setup.py
+++ b/Setup.py
@@ -188,7 +188,7 @@ def conan_install(
 ):
     config_settings = [
         "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']",
-        "tools.build:compiler_executabes={'c':'/opt/homebrew/opt/llvm@14/bin/clang', 'cpp': '/opt/homebrew/opt/llvm@14/bin/clang++'}"
+        "tools.build:compiler_executables={'c':'/opt/homebrew/opt/llvm@14/bin/clang', 'cpp': '/opt/homebrew/opt/llvm@14/bin/clang++'}"
     ]
 
     build_profile = get_profile(sys.platform, get_arch(), BuildMode.release, compiler)

--- a/Setup.py
+++ b/Setup.py
@@ -271,6 +271,9 @@ class ArgTypeEnum(Enum):
     def __str__(self):
         return self.name
 
+def prepare():
+    setup_cmaes()
+    setup_profiles()
 
 def parse_arguments():
     parser = ArgumentParser()
@@ -320,8 +323,7 @@ def parse_arguments():
 if __name__ == "__main__":
 
     opts = parse_arguments()
-    setup_cmaes()
-    setup_profiles()
+    prepare()
 
     options = []
     if opts.options is not None:

--- a/Setup.py
+++ b/Setup.py
@@ -188,7 +188,7 @@ def conan_install(
 ):
     config_settings = [
         "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']",
-        "tools.build:compiler_executables={'c':'/opt/homebrew/opt/llvm@14/bin/clang', 'cpp': '/opt/homebrew/opt/llvm@14/bin/clang++'}"
+        "tools.build:compiler_executables={'c':'/usr/local/opt/llvm@14/bin/clang', 'cpp': '/usr/local/opt/llvm@14/bin/clang++'}"
     ]
 
     build_profile = get_profile(sys.platform, get_arch(), BuildMode.release, compiler)

--- a/Setup.py
+++ b/Setup.py
@@ -187,7 +187,8 @@ def conan_install(
     profile, additional_options=[], build_missing=False, compiler: Compiler = None
 ):
     config_settings = [
-        "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']"
+        "tools.cmake.cmake_layout:build_folder_vars=['settings.os','settings.arch','settings.build_type']",
+        "tools.build:compiler_executabes={'c':'/opt/homebrew/opt/llvm@14/bin/clang', 'cpp': '/opt/homebrew/opt/llvm@14/bin/clang++'}"
     ]
 
     build_profile = get_profile(sys.platform, get_arch(), BuildMode.release, compiler)

--- a/include/BSMPT/utility/utility.h
+++ b/include/BSMPT/utility/utility.h
@@ -15,6 +15,7 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #ifdef Boost_FOUND
 #include <boost/version.hpp>

--- a/include/BSMPT/utility/utility.h
+++ b/include/BSMPT/utility/utility.h
@@ -14,8 +14,8 @@
 #include <numeric>
 #include <random>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #ifdef Boost_FOUND
 #include <boost/version.hpp>


### PR DESCRIPTION
The missing include caused an compile error with clang 14 on mac.
While upgrading to clang 15 fixes the problem, adding the missing include also does and is the cleaner way.