### PR TITLE
Fix negative alpha

### DIFF
--- a/src/bounce_solution/bounce_solution.cpp
+++ b/src/bounce_solution/bounce_solution.cpp
@@ -1107,7 +1107,11 @@ void BounceSolution::CalculatePTStrength()
     double rho_gam = CalculateRhoGamma(GetTransitionTemp());
     alpha = 1 / rho_gam * (Vi - Vf - GetTransitionTemp() / 4. * (dTVi - dTVf));
     CalculateWallVelocity(false_min, true_min);
-    if (abs(alpha / old_alpha - 1) < 1e-7) return; // Found a solution
+    if (abs(alpha / old_alpha - 1) < 1e-7)
+    {
+      if (alpha < 0) status_bounce_sol = StatusGW::Failure; // Unphysical
+      return;                                               // Found a solution
+    }
   }
   // We could not find the solution for the system. use default value of .95
   // instead

--- a/src/gravitational_waves/gw.cpp
+++ b/src/gravitational_waves/gw.cpp
@@ -17,6 +17,10 @@ GravitationalWave::GravitationalWave(
     const TransitionTemperature &which_transition_temp)
 {
   BACalc.SetAndCalculateGWParameters(which_transition_temp);
+
+  if (BACalc.status_bounce_sol == StatusGW::Failure)
+    data.status = StatusGW::Failure;
+
   data.transitionTemp = BACalc.GetTransitionTemp();
   data.reheatingTemp  = BACalc.GetReheatingTemp();
   data.PTStrength     = BACalc.GetPTStrength();

--- a/tests/unittests/Test-gw.cpp
+++ b/tests/unittests/Test-gw.cpp
@@ -615,6 +615,42 @@ TEST_CASE("Checking phase tracking for BP2 - Mode 2", "[gw]")
   REQUIRE(vac.PhasesList.size() == 2);
 }
 
+TEST_CASE("Checking negative alpha case R2HDM", "[gw]")
+{
+  const std::vector<double> example_point_R2HDM{
+      /* lambda_1 = */ 6.1790997800878733,
+      /* lambda_2 = */ 0.25833592686924883,
+      /* lambda_3 = */ 1.4365660325357121,
+      /* lambda_4 = */ -0.88084250125747032,
+      /* lambda_5 = */ -0.58605039437291362,
+      /* m_{12}^2 = */ 405.82270614210461,
+      /* tan(beta) = */ 14.110965513994532,
+      /* Yukawa Type = */ 1};
+
+  using namespace BSMPT;
+  SetLogger({"--logginglevel::complete=true"});
+  const auto SMConstants = GetSMConstants();
+  std::shared_ptr<BSMPT::Class_Potential_Origin> modelPointer =
+      ModelID::FChoose(ModelID::ModelIDs::R2HDM, SMConstants);
+  modelPointer->initModel(example_point_R2HDM);
+
+  user_input input;
+  input.modelPointer   = modelPointer;
+  input.gw_calculation = true;
+  input.T_high         = 1000;
+  TransitionTracer trans(input);
+
+  trans.ListBounceSolution.at(0).SetAndCalculateGWParameters(
+      TransitionTemperature::Percolation);
+
+  auto output = trans.output_store;
+
+  REQUIRE(output.vec_gw_data.at(0).alpha.value() < 0);
+
+  REQUIRE(trans.ListBounceSolution.at(0).status_bounce_sol ==
+          StatusGW::Failure);
+}
+
 TEST_CASE("Checking phase tracking for BP3 with Mode 0", "[gw]")
 {
   const std::vector<double> example_point_CXSM{/* v = */ 245.34120667410863,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the change and the purpose of the PR. -->

In some cases we can have $\Delta V > 0$ but $\alpha < 0$, this is because the trace anomaly has some contribution from the temperature detivative $\frac{d \Delta V}{dT}$ which can have opposite sign. 

## Type of Change

<!-- Please select only a single option with an "x" or "X". -->

 - [ ] Break (major)
 - [ ] Feature (minor)
 - [x] Bug fix (patch)
 - [ ] No source changes (no version change)
